### PR TITLE
Disable Packit notification in pull request

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -39,6 +39,9 @@ jobs:
       - epel-8-aarch64
       - epel-8-x86_64
 
+notifications:
+  pull_request:
+    successful_build: false
 # Restraint is not accepted in Fedora (yet)
 #- job: propose_downstream
   #trigger: release


### PR DESCRIPTION
Packit is creating comments in Pull Request when the first build is finished successfully.
This is unnecessary noise. We should disable it in configuration [0].

[0] https://packit.dev/docs/configuration/#notifications

Signed-off-by: Martin Styk <mastyk@redhat.com>