### PR TITLE
Add pidof as dependency for upstream

### DIFF
--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install deps
       run: |
-        dnf install -y 'dnf-command(builddep)' git-daemon python3-flask python3-requests python3-pytest python3-six
+        dnf install -y 'dnf-command(builddep)' git-daemon python3-flask python3-requests python3-pytest python3-six procps-ng
     - name: Install restraint deps
       run: |
         dnf builddep --spec specfiles/restraint-upstream.spec -y
@@ -46,7 +46,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install deps
       run: |
-        dnf install -y 'dnf-command(builddep)' valgrind git-daemon
+        dnf install -y 'dnf-command(builddep)' valgrind git-daemon procps-ng
     - name: Install restraint deps
       run: |
         dnf builddep --spec specfiles/restraint-upstream.spec -y

--- a/.github/workflows/review-checks.yml
+++ b/.github/workflows/review-checks.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install deps
       run: |
-        dnf install -y 'dnf-command(builddep)' git-daemon python3-flask python3-requests python3-pytest python3-six
+        dnf install -y 'dnf-command(builddep)' git-daemon python3-flask python3-requests python3-pytest python3-six procps-ng
     - name: Install restraint deps
       run: |
         dnf builddep --spec specfiles/restraint-upstream.spec -y
@@ -43,7 +43,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install deps
       run: |
-        dnf install -y 'dnf-command(builddep)' valgrind git-daemon
+        dnf install -y 'dnf-command(builddep)' valgrind git-daemon procps-ng
     - name: Install restraint deps
       run: |
         dnf builddep --spec specfiles/restraint-upstream.spec -y

--- a/specfiles/restraint-upstream.spec
+++ b/specfiles/restraint-upstream.spec
@@ -34,7 +34,8 @@ BuildRequires:		selinux-policy-devel
 Requires(post):		systemd
 Requires(pre):		systemd
 Requires(postun):	systemd
-Requires:			selinux-policy
+Requires:		selinux-policy
+Requires:		/usr/bin/pidof
 
 %description
 restraint harness which can run standalone or with beaker.  when provided a recipe xml it will execute


### PR DESCRIPTION
Recent changes made pidof a dependency for Restraint and checks running
on containers are failing because pidof is missing.

Add /usr/bin/pidof as requirement in upstream specfile.

Add procps-ng package to GitHub workflows dependency steps.

Note that requirement for downstream will be addressed separately.

Fixes #16