### PR TITLE
tests: Add git tests to skip without git daemon

### DIFF
--- a/src/run-tests.sh
+++ b/src/run-tests.sh
@@ -45,7 +45,11 @@ if [[ -f /usr/libexec/git-core/git-daemon ]] ; then
         --base-path=test-data/git-remote --export-all --enable=upload-archive \
         --verbose --detach --pid-file=${GITD_PID_FILE}
 else
-    testargs="-s /fetch_git/success -s /fetch_git/fail -s /fetch_git/keepchanges $testargs"
+    testargs="--keep-going \
+        -s /fetch_git/success -s /fetch_git/fail -s /fetch_git/keepchanges \
+        -s /repodeps/git/success -s /repodeps/git/fail \
+        -s /repodeps/recursive/git/success -s /repodeps/recursive/git/fail \
+        ${testargs}"
 fi
 
 guess_python_version() {


### PR DESCRIPTION
When the Git daemon is not available, tests that depend on it are
skipped. Some tests were missing from the skip list.

Add git tests to the skip list.

Add the --keep-going option to avoid the test suite to fail when all
tests are skipped.