### PR TITLE
tests: Add procps-ng dep for containers

### DIFF
--- a/containers/provision/fedora:latest.sh
+++ b/containers/provision/fedora:latest.sh
@@ -6,6 +6,7 @@ dnf -y install 'dnf-command(builddep)' \
 	python3-flask \
 	python3-requests \
 	python3-pytest \
-	python3-six
+	python3-six \
+	procps-ng
 
 dnf -y builddep --spec /restraint/specfiles/restraint-upstream.spec


### PR DESCRIPTION
The pidof program is required by restraint and it's needed in tests.