### PR TITLE
tests: Add cmd_utils unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@
 /src/test_cmd_abort
 /src/test_cmd_log
 /src/test_cmd_result
+/src/test_cmd_utils
 /src/test_cmd_watchdog
 /src/test_fetch_task
 /src/test_metadata

--- a/src/Makefile
+++ b/src/Makefile
@@ -94,6 +94,7 @@ restraint_forkpty.o:
 TEST_PROGRAMS += test_cmd_abort
 TEST_PROGRAMS += test_cmd_log
 TEST_PROGRAMS += test_cmd_result
+TEST_PROGRAMS += test_cmd_utils
 TEST_PROGRAMS += test_cmd_watchdog
 TEST_PROGRAMS += test_dependency
 TEST_PROGRAMS += test_env
@@ -142,6 +143,8 @@ test_cmd_result.o: cmd_result.h utils.h cmd_utils.h upload.h errors.h
 
 test_cmd_watchdog: cmd_watchdog.o utils.o cmd_utils.o errors.o
 test_cmd_watchdog.o: cmd_watchdog.h utils.h cmd_utils.h errors.h
+
+test_cmd_utils: test_cmd_utils.o cmd_utils.o env.o utils.o errors.o
 
 test_utils: test_utils.o utils.o errors.o
 

--- a/src/test-dummies/cmd_utils/bin/pidof
+++ b/src/test-dummies/cmd_utils/bin/pidof
@@ -1,0 +1,1 @@
+spawned_mock

--- a/src/test-dummies/cmd_utils/bin/spawned_mock
+++ b/src/test-dummies/cmd_utils/bin/spawned_mock
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+MOCK_NAME=$(/usr/bin/basename "$0" | /usr/bin/tr 'a-z' 'A-Z')
+
+stdout_value=$(eval echo \$MOCK_"${MOCK_NAME}"_STDOUT)
+stderr_value=$(eval echo \$MOCK_"${MOCK_NAME}"_STDERR)
+exit_value=$(eval echo \$MOCK_"${MOCK_NAME}"_EXIT)
+
+if [ -n "${stdout_value}" ] ; then
+	echo "${stdout_value}"
+fi
+
+if [ -n "${stderr_value}" ] ; then
+	echo "${stderr_value}" >&2
+fi
+
+exit ${exit_value:-255}

--- a/src/test_cmd_utils.c
+++ b/src/test_cmd_utils.c
@@ -1,0 +1,129 @@
+#include <glib.h>
+
+#include "cmd_utils.h"
+#include "errors.h"
+
+static void
+test_get_restraintd_pid_success (void)
+{
+    gchar  *path_bkp;
+    gint    restraintd_pid;
+    GError *error;
+
+    path_bkp = g_strdup (g_getenv ("PATH"));
+    g_setenv ("PATH", "./test-dummies/cmd_utils/bin", TRUE);
+
+    g_setenv ("MOCK_PIDOF_STDOUT", "123", TRUE);
+    g_setenv ("MOCK_PIDOF_EXIT", "0", TRUE);
+
+    error = NULL;
+
+    restraintd_pid = get_restraintd_pid (&error);
+
+    g_setenv ("PATH", path_bkp, TRUE);
+
+    g_unsetenv ("MOCK_PIDOF_STDOUT");
+    g_unsetenv ("MOCK_PIDOF_EXIT");
+
+    g_assert_no_error (error);
+    g_assert_cmpint (restraintd_pid, ==, 123);
+
+    g_free (path_bkp);
+}
+
+static void
+test_get_restraintd_pid_many_pids (void)
+{
+    GError *error;
+    gchar  *expected_regex;
+    gchar  *path_bkp;
+    gint    restraintd_pid;
+
+    path_bkp = g_strdup (g_getenv ("PATH"));
+    g_setenv ("PATH", "./test-dummies/cmd_utils/bin", TRUE);
+
+    g_setenv ("MOCK_PIDOF_STDOUT", "123 124 125", TRUE);
+    g_setenv ("MOCK_PIDOF_EXIT", "0", TRUE);
+
+    expected_regex = "Due to multiple restraintd .+";
+
+    error = NULL;
+
+    restraintd_pid = get_restraintd_pid (&error);
+
+    g_setenv ("PATH", path_bkp, TRUE);
+
+    g_unsetenv ("MOCK_PIDOF_STDOUT");
+    g_unsetenv ("MOCK_PIDOF_EXIT");
+
+    g_assert_cmpint (restraintd_pid, ==, 0);
+    g_assert_error (error, RESTRAINT_ERROR, RESTRAINT_TOO_MANY_RESTRAINTD_RUNNING);
+    g_assert_true (g_regex_match_simple (expected_regex, error->message, 0, 0));
+
+    g_clear_error (&error);
+    g_free (path_bkp);
+}
+
+static void
+test_get_restraintd_pid_spawn_fail (void)
+{
+    GError *error;
+    gchar  *expected_msg_regex;
+    gchar  *path_bkp;
+    gint    restraintd_pid;
+
+    expected_msg_regex = "Failed to spawn command: .+";
+
+    path_bkp = g_strdup (g_getenv ("PATH"));
+    g_setenv ("PATH", "", TRUE);
+
+    error = NULL;
+
+    restraintd_pid = get_restraintd_pid (&error);
+
+    g_setenv ("PATH", path_bkp, TRUE);
+
+    g_assert_cmpint (restraintd_pid, ==, 0);
+    g_assert_error (error, RESTRAINT_ERROR, RESTRAINT_CMDLINE_ERROR);
+    g_assert_true (g_regex_match_simple (expected_msg_regex, error->message, 0, 0));
+
+    g_clear_error (&error);
+    g_free (path_bkp);
+}
+
+static void
+test_get_restraintd_pid_no_restraintd (void)
+{
+    GError *error;
+    gint    restraintd_pid;
+
+    error = NULL;
+
+    /* Hopefully, there is no restraintd on the system running the tests.
+     * TODO: This should be mocked too. */
+    restraintd_pid = get_restraintd_pid (&error);
+
+    g_assert_cmpint (restraintd_pid, ==, 0);
+    g_assert_error (error, RESTRAINT_ERROR, RESTRAINT_NO_RESTRAINTD_RUNNING_ERROR);
+    g_assert_cmpstr (error->message, ==, "Failed to get restraintd pid. Server not running.");
+
+    g_clear_error (&error);
+}
+
+int
+main (int   argc,
+      char *argv[])
+{
+    g_test_init (&argc, &argv, NULL);
+
+    g_test_add_func ("/cmd_utils/get_restraintd_pid/success",
+                     test_get_restraintd_pid_success);
+    g_test_add_func ("/cmd_utils/get_restraintd_pid/many_pids",
+                     test_get_restraintd_pid_many_pids);
+    g_test_add_func ("/cmd_utils/get_restraintd_pid/spawn_fail",
+                     test_get_restraintd_pid_spawn_fail);
+    g_test_add_func ("/cmd_utils/get_restraintd_pid/no_restraintd",
+                     test_get_restraintd_pid_no_restraintd);
+
+    return g_test_run ();
+}


### PR DESCRIPTION
Add unit tests for get_restraintd_pid.

Add basic mocking for spawned programs.

Relates to #34 