### PR TITLE
Doc: Detail how to remove rhts from jobs

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -291,6 +291,8 @@ this command::
     RSTRNT_PKG_DELAY:    Number of seconds to delay between retries.
                          default: 1
 
+.. _p_reboot:
+
 rstrnt-prepare-reboot
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -315,8 +317,9 @@ No arguments are required to run this command.
 rstrnt-reboot
 ~~~~~~~~~~~~~
 
-Helper to reboot the system. On UEFI systems it will use efibootmgr to set next
-boot to what is booted currently.  No arguments are required to run this command.
+Helper to soft reboot the system. On UEFI systems, it will use efibootmgr
+to set next boot to what is booted currently.  No arguments are required to run
+this command.
 
 rstrnt-report-log
 ~~~~~~~~~~~~~~~~~
@@ -421,6 +424,8 @@ Where:
 .. option::  METRIC
 
     Optional result metric
+
+.. _legacy_rpt_mode:
 
 Legacy Reporting Mode
 """""""""""""""""""""
@@ -640,46 +645,6 @@ Here is an example command to covert a job run XML into JUnit results.
 Legacy RHTS Commands
 --------------------
 
-If you have the restraint-rhts subpackage installed these commands are provided
-in order to support legacy tests written for RHTS.
-
-rhts-backup
-~~~~~~~~~~~
-
-Use `rstrnt-backup` instead.
-
-rhts-environment.sh
-~~~~~~~~~~~~~~~~~~~
-
-Deprecated.
-
-rhts-lint
-~~~~~~~~~
-
-Deprecated - only provided so that testinfo.desc can be generated.
-
-rhts-sync-block
-~~~~~~~~~~~~~~~
-
-Use `rstrnt-sync-block` instead.
-
-rhts-sync-set
-~~~~~~~~~~~~~
-
-Use `rstrnt-sync-set` instead.
-
-rhts-reboot
-~~~~~~~~~~~
-
-Use `rstrnt-reboot` instead.
-
-rhts-restore
-~~~~~~~~~~~~
-
-Use `rstrnt-restore` instead.
-
-rhts-run-simple-test
-~~~~~~~~~~~~~~~~~~~~
-
-Deprecated.
-
+Prior to the `Restraint` harness, users used `RHTS` commands in their jobs.
+These are being deprecated and substitutes for those legacy commands can be
+found in :ref:`legacy_rhts_cmds`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,6 +52,7 @@ Contents:
    using
    release-notes
    develop
+   remove_rhts
    todo
 
 Additional Information

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -1,3 +1,5 @@
+.. _plugins:
+
 Plugins
 =======
 
@@ -203,7 +205,9 @@ to check for false positives.
   forward.
 
 If you need to skip error checking, refer to RSTRNT_DISABLED as described
-in the environment variable section (see :ref:`env-variables`).
+in the :ref:`env_variables` section.
+
+.. _lcl_wd_p_in:
 
 Local Watchdog
 --------------
@@ -224,7 +228,7 @@ limit. Restraint currently ships with three plugins:
 
 * 99_reboot - Simply reboots the system to try and get the system back to a
   sane state.  If you need to skip this step, you can use RSTRNT_DISABLED
-  as described in (see :ref:`env-variables`).
+  as described in (see :ref:`env_variables`).
 
 .. _completed:
 
@@ -255,6 +259,6 @@ To finish our tcpdump example from above we can add the following::
  chmod a+x /usr/share/restraint/plugins/completed.d/80_upload_tcpdump
 
 If you need to skip file restoration, refer to RSTRNT_DISABLED as described
-in the environment variable section (see :ref:`env-variables`).
+in the environment variable section (see :ref:`env_variables`).
 
 .. [#] `Beaker Multihost documentation <https://beaker-project.org/docs/user-guide/multihost.html>`_.

--- a/docs/remove_rhts.rst
+++ b/docs/remove_rhts.rst
@@ -1,0 +1,273 @@
+Guide to removing RHTS from Jobs
+================================
+
+For some products, Test Requirements include running restraint by itself.
+This requires the exclusion of the legacy RHTS package or `restraint-rhts`
+package installation.  Below lists areas to draw attention in order
+to eliminate RHTS references.
+
+#. Use the `restraint` harness package and not `restraint-rhts` in your jobs.
+#. Avoid defining tasks or dependencies which cause installation of the `RHTS` library.
+#. Replace `RHTS` scripts with `Restraint` scripts.  :ref:`legacy_rhts_cmds` provides
+   a table which maps legacy to restraint scripts.
+#. Change your tasks to utilize `Restraint's metadata` file instead of `RHTS`
+   `testinfo.desc` file. :ref:`legacy_metadata` provides details on mapping
+   legacy `testinfo.desc` variables to restraint `metadata` variables. Depending
+   on how your task is written, you may have to update or remove `Makefiles` so they
+   do not process the `testinfo.desc` file.  An example of this is also
+   included in the referenced section.
+#. Replace `RHTS` environment variables with `Restraint` variables. A table listing
+   `RHTS Legacy Variables` to `Restraint Substitute` can be found in
+   :ref:`legacy_env_var`.
+
+.. _legacy_rhts_cmds:
+
+Replacement for RHTS Scripts
+----------------------------
+
+The table below lists known legacy RHTS commands.  Some are provided in the
+`restraint-rhts` package and some are from `rhts` package.  It is encouraged for people
+to use `Restraint`'s substitute for these commands as they are actively supported.
+Included in the table are the `Restraint` substitutes and which RHTS commands are deprecated.
+
++--------------------------------+-------------------------------------------+
+| RHTS Legacy Script             | Restraint Substitute                      |
++================================+===========================================+
+| rhts-abort                     | rstrnt-abort                              |
++--------------------------------+-------------------------------------------+
+| rhts-backup                    | rstrnt-backup                             |
++--------------------------------+-------------------------------------------+
+| rhts-db-submit-result,         | rstrnt-report-result.d plugin             |
+| rhts_db_submit_result          | :ref:`rpt_result` (See Note)              |
++--------------------------------+-------------------------------------------+
+| rhts-environment.sh,           | None                                      |
+| rhts_environment.sh            |                                           |
++--------------------------------+-------------------------------------------+
+| rhts-extend                    | rstrnt-adjust-watchdog                    |
++--------------------------------+-------------------------------------------+
+| rhts-flush                     | None                                      |
++--------------------------------+-------------------------------------------+
+| rhts-lint                      | None                                      |
++--------------------------------+-------------------------------------------+
+| rhts-power                     | None                                      |
++--------------------------------+-------------------------------------------+
+| rhts-reboot                    | rstrnt-reboot                             |
++--------------------------------+-------------------------------------------+
+| rhts-recipe-sync-block,        | rstrnt-sync-block                         |
+| rhts_recipe_sync_block         |                                           |
++--------------------------------+-------------------------------------------+
+| rhts-recipe-sync-set,          | rstrnt-sync-set                           |
+| rhts_recipe_sync_set           |                                           |
++--------------------------------+-------------------------------------------+
+| rhts-report-result             | rstrnt-report-result                      |
++--------------------------------+-------------------------------------------+
+| rhts-restore                   | rstrnt-restore                            |
++--------------------------------+-------------------------------------------+
+| rhts-run-simple-test           | None                                      |
++--------------------------------+-------------------------------------------+
+| rhts-submit-log,               | rstrnt-report-log                         |
+| rhts_submit_log                |                                           |
++--------------------------------+-------------------------------------------+
+| rhts-sync-block,               | rstrnt-sync-block                         |
+| rhts_sync_block                |                                           |
++--------------------------------+-------------------------------------------+
+| rhts-sync-set,                 | rstrnt-sync-set                           |
+| rhts_sync_set                  |                                           |
++--------------------------------+-------------------------------------------+
+| rhts-system-info               | localwatchdog.d 20_sysinfo plugin         |
+|                                | :ref:`lcl_wd_p_in` (See Note)             |
++--------------------------------+-------------------------------------------+
+
+
+.. note::
+    Some functionality in `RHTS` scripts are replaced by `Restraint` plugins.  Links
+    for details on those plugins are contained in the `Restraint Substitute` column.
+
+.. _legacy_metadata:
+
+Replacement for RHTS testinfo.desc File
+---------------------------------------
+
+Legacy `RHTS` tests use the `testinfo.desc` file for their metadata [#]_. `Restraint`
+supports generating (via the Makefile) and reading this file; however, `Restraint`
+does not process all the fields in this file. `Restraint` gives the `metadata` file
+predecence over the `testinfo.desc` file.
+
+The tables below shows is a list of `testinfo.desc` variables `Restraint` parses
+and acts on.  The table also shows the mapping to `Restraint` metadata
+section/variable.
+
++------------------------+----------------------------------------+
+| testinfo.desc variable | metadata [section] variable substitute |
++========================+========================================+
+| Name                   | [General] name                         |
++------------------------+----------------------------------------+
+| Environment            | [restraint] environment                |
++------------------------+----------------------------------------+
+| TestTime               | [restraint] max_time                   |
++------------------------+----------------------------------------+
+| Requires               | [restraint] dependencies               |
++------------------------+----------------------------------------+
+| RhtsRequires           | [restraint] dependencies               |
++------------------------+----------------------------------------+
+| USE_PTY                | [restraint] use_pty                    |
++------------------------+----------------------------------------+
+
+The following are informational variables and should be maintained.
+`Restraint` does not perform any action on these variables.
+
++------------------------+----------------------------------------+
+| testinfo.desc variable | metadata [section] variable substitute |
++========================+========================================+
+| License                | [General] license                      |
++------------------------+----------------------------------------+
+| Owner                  | [General] owner                        |
++------------------------+----------------------------------------+
+| Description            | [General] description                  |
++------------------------+----------------------------------------+
+| Confidential           | [General] confidential                 |
++------------------------+----------------------------------------+
+| Destructive            | [General] destructive                  |
++------------------------+----------------------------------------+
+
+There are no substitutes for the following `Makefile/testinfo.desc` variables
+in `Restraint's` metadata file.  Some of these variables are
+informational and can be added in the metadata file but it is just
+documentation.  `Restraint` will not act on them and they will be ignored.
+
+* TESTVERSION
+* FILES
+* BUILT_FILES
+* TEST_DIR
+* Path
+* Architectures
+* Bugs
+* Priority
+* Releases
+* RhtsOptions
+* TestVersion
+
+Example of removing testinfo.desc file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The sample files below show converting `Makefile/testinfo.desc` to `metadata` file.
+The Makefile does not have to be removed in its entirety. In the Sample Makefile,
+everything from `rhts-make.include` below should be removed.  If the
+upper part of the Makefile is kept, the `entry_point` variable defined in the `metadata`
+file is not required since `Restraint` will perform `make run` when `entry_point` is
+not present.
+
+Sample Makefile::
+
+ export TEST=/examples/no-rhts/sample-before
+ export TESTVERSION=1.0
+
+ BUILT_FILES=
+
+ FILES=$(METADATA) runtest.sh Makefile PURPOSE
+
+ .PHONY: all install download clean
+
+ run: $(FILES) build
+         ./runtest.sh
+
+ build: $(BUILT_FILES)
+         test -x runtest.sh || chmod a+x runtest.sh
+
+ clean:
+         rm -f *~ $(BUILT_FILES)
+
+ include /usr/share/rhts/lib/rhts-make.include
+
+ $(METADATA): Makefile
+         @echo "Owner:           User ABC1 <userabc1@example.com>" > $(METADATA)
+         @echo "Name:            $(TEST)" >> $(METADATA)
+         @echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
+         @echo "Path:            $(TEST_DIR)" >> $(METADATA)
+         @echo "Description:     Sample-before-no-rhts" >> $(METADATA)
+         @echo "Type:            Sanity" >> $(METADATA)
+         @echo "TestTime:        5m" >> $(METADATA)
+         @echo "Priority:        Normal" >> $(METADATA)
+         @echo "License:         GPLv2+" >> $(METADATA)
+         @echo "Confidential:    no" >> $(METADATA)
+         @echo "Destructive:     no" >> $(METADATA)
+         @echo "Releases:        -RHEL7 -RHEL8" >> $(METADATA)
+         @echo "Architectures:   x86_64" >> $(METADATA)
+
+Makefile generated `testinfo.desc` file::
+
+ Owner:           User ABC1 <userabc1@example.com>
+ Name:            /examples/no-rhts/sample-before
+ TestVersion:     1.0
+ Path:            /mnt/tests/examples/no-rhts/sample-before
+ Description:     Sample-before-no-rhts
+ Type:            Sanity
+ TestTime:        5m
+ Priority:        Normal
+ License:         GPLv2+
+ Confidential:    no
+ Destructive:     no
+ Releases:        -RHEL7 -RHEL8
+ Architectures:   x86_64
+
+Replacement restraint `metadata` file with no Makefile::
+
+ [General]
+ description=Sample-after-no-rhts
+ owner=User ABC1 <userabc1@example.com>
+ license=GPLv2+
+ confidential=no
+ destructive=no
+
+ [restraint]
+ entry_point=./runtest.sh
+ max_time=5m
+ name=/examples/no-rhts/sample-after
+
+.. _legacy_env_var:
+
+Legacy RHTS Task Environment Variables
+--------------------------------------
+
+When the `testinfo.desc` file is present, `Restraint` exports the
+`RHTS` Legacy variables to support legacy tests written for
+`RHTS` (Red Hat Test System).  Both the `testinfo.desc` file
+and these variables are being deprecated and the table below lists
+the variable substitutes.
+
++----------------------+----------------------------------+
+| RHTS Legacy Variable | Restraint Substitute             |
++======================+==================================+
+| ARCH                 | RSTRNT_OSARCH                    |
++----------------------+----------------------------------+
+| DISTRO               | RSTRNT_OSDISTRO                  |
++----------------------+----------------------------------+
+| FAMILY               | RSTRNT_OSMAJOR                   |
++----------------------+----------------------------------+
+| JOBID                | RSTRNT_JOBID                     |
++----------------------+----------------------------------+
+| REBOOTCOUNT          | RSTRNT_REBOOTCOUNT               |
++----------------------+----------------------------------+
+| RECIPESETID          | RSTRNT_RECIPESETID               |
++----------------------+----------------------------------+
+| RECIPEID             | RSTRNT_RECIPEID                  |
++----------------------+----------------------------------+
+| RECIPETESTID         | RSTRNT_RECIPEID                  |
++----------------------+----------------------------------+
+| RESULT_SERVER        | No equivalent. Communication     |
+|                      | only with client/lab controller. |
++----------------------+----------------------------------+
+| SUBMITTER            | RSTRNT_OWNER                     |
++----------------------+----------------------------------+
+| TASKID               | RSTRNT_TASKID                    |
++----------------------+----------------------------------+
+| TESTID               | RSTRNT_TASKID                    |
++----------------------+----------------------------------+
+| TESTNAME             | RSTRNT_TASKNAME                  |
++----------------------+----------------------------------+
+| TESTPATH             | RSTRNT_TASKPATH                  |
++----------------------+----------------------------------+
+| VARIANT              | RSTRNT_OSVARIANT                 |
++----------------------+----------------------------------+
+
+.. [#] `RHTS Task Metadata <https://beaker-project.org/docs/user-guide/task-metadata.html>`_.
+

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -7,18 +7,18 @@ Restraint doesn't require tasks to be written in any particular language. In
 fact, most tests are written in a mixture of shell, python and C code. You do
 need to provide some metadata in order for things to work best.
 
-Metadata
---------
+Restraint Metadata File
+-----------------------
 
-Restraint will look for a file called metadata in the task directory. The
-format for that file is a simple ini file which most people should be familiar
+`Restraint` will look for a file called metadata in the task directory. The
+format for that file is a simple `ini` file which most people should be familiar
 with.
 
 ::
 
  [General]
  name=/restraint/env/metadata
- owner=Bill Peck <bpeck@redhat.com>
+ owner=User ABC1 <userabc1@example.com>
  description=just reports env variables
  license=GPLv2
  confidential=no
@@ -28,24 +28,32 @@ with.
  entry_point=./runtest.sh
  max_time=5m
  dependencies=gcc;emacs
+ softDependencies=numactl;numactl-devel
+ environment=META_VAR1=var1value;META_VAR2=var2value;META_VAR3=var3value
+ repoRequires=general/include;filesystems/include
+ no_localwatchdog=true
  use_pty=false
- #use_pty=true # to enable a pty
 
-The "General" section is mostly used for informational purposes. The only
-element that Restraint will read from here is the name attribute. If defined
-this will over write the task name specified from the job XML.
+`restraintd` does not require any metadata fields to be present. In other words,
+there are no checks and reporting of errors if metadata is not present.  This allows
+flexibility in your configuration.
 
-The "restraint" section has the following elements which can be defined:
+The `General` section is mostly used for informational data. The only
+element that `Restraint` will process is the `name` attribute. If defined,
+this will overwrite the task name specified from the job XML.
+
+The `restraint` section has the following elements which can be defined:
 
 entry_point
 ~~~~~~~~~~~
 
 This tells Restraint how it should start running the task. If you don't
 specify a program to run it will default to 'make run' which is what legacy
-RHTS (Red Hat Test System) would do. Other examples of entry points:
+RHTS (Red Hat Test System) would do. This would require you provide a
+Makefile. Other examples of entry points::
 
-* entry_point=autotest-local control-file
-* entry_point=STAF local PROCESS START SHELL COMMAND "ps | grep test | wc >testcount.txt"
+ * entry_point=autotest-local control-file
+ * entry_point=STAF local PROCESS START SHELL COMMAND "ps | grep test | wc >testcount.txt"
 
 max_time
 ~~~~~~~~
@@ -54,12 +62,12 @@ The maximum time a task is expected to run. When restraintd runs a task it
 sets up a localwatchdog which will kill the task after this time has expired.
 When run in Beaker this is also used for the external watchdog (typically 20-30
 minutes later than the local watchdog time). Time units can be specified as
-follows:
+follows::
 
-* d for days
-* h for hours
-* m for minutes
-* s for seconds
+ * d for days
+ * h for hours
+ * m for minutes
+ * s for seconds
 
 To set a max run time for 2 days you would use the following:
 
@@ -174,22 +182,10 @@ PostgreSQL on everything else.
  dependencies=postgresql
  dependencies[RedHatEnterpriseLinuxServer5]=rhdb
 
-testinfo.desc
--------------
+Legacy Metadata File
+--------------------
 
-Legacy RHTS tests use this file for their metadata [#]_. Restraint supports
-generating (via the Makefile) and reading this file. But Restraint does not
-understand all the fields in this file. The following are the ones Restraint
-parses:
-
- * Name - Same as [General] name
- * Environment- Same as [restraint] environment
- * TestTime - Same as [restraint] max_time
- * Requires - Same as [restraint] dependencies
- * RhtsRequires - Same as [restraint] dependencies
- * RepoRequires - Same as [restraint] repoRequires
- * USE_PTY - Same as [restraint] use_pty
-
-Please see the Beaker documentation for how to populate these fields.
-
-.. [#] `RHTS Task Metadata <https://beaker-project.org/docs/user-guide/task-metadata.html>`_.
+Prior to the `Restraint` harness, users defined `testinfo.desc` file as the
+metadata file in their job tasks and restraint supported that file.  This
+is being deprecated and the substitute for this file and variables
+within can be found in :ref:`legacy_metadata`.

--- a/docs/variables.rst
+++ b/docs/variables.rst
@@ -1,50 +1,130 @@
-.. _env-variables:
+.. _env_variables:
 
-Environment Variables
-=====================
+Task Environment Variables
+==========================
 
-The following environment variables are available to tasks.  They can be
-set using the environment variable of the `metadata` file or
+Restraint exports the following environment variables for task use.
+They can be altered using the environment variable of the `metadata` file or
 `testinfo.desc` file (see :ref:`tasks`).
 
-* RSTRNT_DISABLED - User populated to disable a plugin from running.
-      For example, to prevent `99_reboot` plugin from running after
-      local watchdog expires do `RSTRNT_DISABLED="99_reboot"`. Add
-      a space inbetween if there are multiple plugins.
-      For example, do `RSTRNT_DISABLED="01_dmesg_check 10_avc_check"`.
-      to prevent error checking (though not advised).
-* RSTRNT_JOBID - Populated from the job_id attribute of the recipe node.
-* RSTRNT_OWNER - Populated from the owner attribute of the job node.
-* RSTRNT_RECIPESETID - Populated from the recipe_set_id attribute of the recipe
-  node.
-* RSTRNT_RECIPEID - Populated from the id attribute of the recipe node.
-* RSTRNT_TASKID - Populated from the id attribute of the task node.
-* RSTRNT_OSDISTRO - Name of the distro (only defined if running in Beaker).
-* RSTRNT_OSMAJOR - Fedora19 or CentOS5.
-* RSTRNT_OSVARIANT - Server, Client, not all distros use variants.
-* RSTRNT_OSARCH
-* RSTRNT_TASKNAME - Name of task "/distribution/install".
-* RSTRNT_TASKPATH - Where the task is installed.
-* RSTRNT_MAXTIME - Max time in seconds for this task to complete.
-* RSTRNT_REBOOTCOUNT - The number of times the system has rebooted for this task.
-* RSTRNT_TASKORDER
++----------------------+------------------------------------------------------+-----------+
+| Restraint Variables  | Description                                          | Source    |
++======================+======================================================+===========+
+| HOME                 | home directory defaults to /root. Can be overwritten | Static    |
+|                      | using recipe or task params.                         |           |
++----------------------+------------------------------------------------------+-----------+
+| HOSTNAME             | Set by task plugin before execution of user task     | Task      |
+|                      |                                                      | Plugin    |
++----------------------+------------------------------------------------------+-----------+
+| LANG                 | Environment variable to specify locale.  The default | Static    |
+|                      | is `en_US.UTF-8`.  It can be overwritten using       |           |
+|                      | recipe or task params.                               |           |
++----------------------+------------------------------------------------------+-----------+
+| PATH                 | Program search path environment variable. The default| Static    |
+|                      | default is "/usr/local/bin:/usr/bin:/bin:            |           |
+|                      | /usr/local/sbin:/usr/sbin:/sbin". It can be          |           |
+|                      | overwritten using recipe or task params.             |           |
++----------------------+------------------------------------------------------+-----------+
+| RSTRNT_JOBID         | Populated from the job_id attribute of the recipe    | Job       |
+|                      | node.                                                |           |
++----------------------+------------------------------------------------------+-----------+
+| RSTRNT_MAXTIME       | Max time in seconds for this task to complete.       | Job       |
+|                      | Input to local and external watchdog timers.         |           |
++----------------------+------------------------------------------------------+-----------+
+| RSTRNT_OSARCH        | OS Architectures. Ex: x86_64, s390x, i386, aarch64,  | Job/Task  |
+|                      | ppc64, ppc64le, armhfp                               | Plugin    |
++----------------------+------------------------------------------------------+-----------+
+| RSTRNT_OSDISTRO      | Name of the distro (Provided if running in Beaker).  | Job       |
++----------------------+------------------------------------------------------+-----------+
+| RSTRNT_OSMAJOR       | OS Major Version of Distro. Ex: Fedora31, CentOS7,   | Job/Task  |
+|                      | RedHatEnterpriseLinux8                               | Plugin    |
++----------------------+------------------------------------------------------+-----------+
+| RSTRNT_OSVARIANT     | Not all distros use variants. Ex: Server, Client     | Job       |
++----------------------+------------------------------------------------------+-----------+
+| RSTRNT_OWNER         | Populated from the owner attribute of the job node.  | Job       |
++----------------------+------------------------------------------------------+-----------+
+| RSTRNT_REBOOTCOUNT   | The number of times the system has rebooted for this | Restraint |
+|                      | task. If no reboot occurred, the values is 0.        |           |
++----------------------+------------------------------------------------------+-----------+
+| RSTRNT_RECIPEID      | Populated from the id attribute of the recipe node.  | Job       |
++----------------------+------------------------------------------------------+-----------+
+| RSTRNT_RECIPESETID   | Populated from the recipe_set_id attribute of the    | Job       |
+|                      | recipe node.                                         |           |
++----------------------+------------------------------------------------------+-----------+
+| RSTRNT_TASKID        | Populated from the id attribute of the task node.    | Job       |
++----------------------+------------------------------------------------------+-----------+
+| RSTRNT_TASKNAME      | Name of task from the job.                           | metadata  |
+|                      | Ex: "/distribution/command".                         |           |
++----------------------+------------------------------------------------------+-----------+
+| RSTRNT_TASKORDER     | Sequence Order of tasks multiplied by 2. Used by     | Restraint |
+|                      | Restraint when it performs multihosting.             |           |
++----------------------+------------------------------------------------------+-----------+
+| RSTRNT_TASKPATH      | Where the task is installed.                         | rpm path/ |
+|                      |                                                      | Restraint |
++----------------------+------------------------------------------------------+-----------+
+| TERM                 | Terminal type defaults to `vt100`. Can be            | Static    |
+|                      | overwritten using recipe or task params.             |           |
++----------------------+------------------------------------------------------+-----------+
+| TESTID               | Contains the ID assigned to this task.               | Job       |
++----------------------+------------------------------------------------------+-----------+
 
-These variables are provided in order to support legacy tests written for RHTS
-(Red Hat Test System).
+For legacy RHTS variables, refer to :ref:`legacy_env_var`.
 
-* JOBID - use RSTRNT_JOBID instead.
-* SUBMITTER - use RSTRNT_OWNER instead.
-* RECIPESETID - use RSTRNT_RECIPESETID instead.
-* RECIPEID - use RSTRNT_RECIPEID instead.
-* RECIPETESTID - use RSTRNT_RECIPEID instead.
-* TESTID - Use RSTRNT_TASKID instead.
-* TASKID - use RSTRNT_TASKID instead.
-* REBOOTCOUNT - use RSTRNT_REBOOTCOUNT instead.
-* DISTRO - Use RSTRNT_OSDISTRO instead.
-* VARIANT - Use RSTRNT_OSVARIANT instead.
-* FAMILY - Use RSTRNT_OSMAJOR instead.
-* ARCH - Use RSTRNT_OSARCH instead.
-* TESTNAME - Use RSTRNT_TASKNAME instead.
-* TESTPATH - Use RSTRNT_TASKPATH instead.
-* RESULT_SERVER - There is no equivalent, communication is only with the Beaker
-  lab controller.
+Script/Plugin Environment Variables
+===================================
+
+This table lists environment variables which affect outcome of restraint scripts and plugins.
+These variables are often set by the user.  They are as follows:
+
++----------------------+------------------------------------------------------+-----------+
+| Restraint Variables  | Description                                          | Source    |
++======================+======================================================+===========+
+| AVC_ERROR            | Refer to :ref:`legacy_rpt_mode` for replacement.     | User      |
++----------------------+------------------------------------------------------+-----------+
+| FAILURESTRINGS       | Used by report_result plugin to report user's task.  | User      |
+| FALSESTRINGS         | Details can be found :ref:`rpt_result`               |           |
++----------------------+------------------------------------------------------+-----------+
+| CLIENTS, SERVERS,    | Assist in the execution of the scripts               | User      |
+| DRIVERS              | rstrnt-sync-block/set. :ref:`rstrnt-sync-block`      |           |
++----------------------+------------------------------------------------------+-----------+
+| NEXTBOOT_VALID_TIME  | Assist in the execution of the script                | Default/  |
+|                      | rstrnt-prepare-reboot. :ref:`p_reboot`               | User      |
++----------------------+------------------------------------------------------+-----------+
+| OUTPUTFILE           | Used by localwatchdog plugin to report user's task   | User      |
+|                      | output if set.                                       |           |
++----------------------+------------------------------------------------------+-----------+
+| TESTPATH/logs2get    | File used by localwatchdog plugin to log user's      | User      |
+|                      | files listed in logs2get.                            |           |
++----------------------+------------------------------------------------------+-----------+
+| RSTRNT_BACKUP_DIR    | To specify directory when using using Restraint's    | User      |
+|                      | backup/restore scripts. :ref:`rstrnt-backup`         |           |
++----------------------+------------------------------------------------------+-----------+
+| RSTRNT_DISABLED      | User populated to disable a plugin from running. Do  | User      |
+|                      | `RSTRNT_DISABLED="99_reboot"` to prevent `99_reboot` |           |
+|                      | from running after local watchdog expires. Do        |           |
+|                      | `RSTRNT_DISABLED="01_dmesg_check 10_avc_check"` to   |           |
+|                      | prevent multiple error checking plugins from running |           |
+|                      | (though disabling these is not advised).             |           |
++----------------------+------------------------------------------------------+-----------+
+| RSTRNT_DISABLE_LINGER| Used by task_run plugin to disable user lingering.   | User      |
+|                      | Refer to OS command loginctl enable/disable linger   |           |
+|                      | for details.  This was introduced due to behavior    |           |
+|                      | changes from Fedora24+. Default is to enable.        |           | 
++----------------------+------------------------------------------------------+-----------+
+| RSTRNT_LOGGING       | Enables debugging for plugins. Default: 3            | User      |
+|                      | (1=Debug, 2=Info, 3=Warning, 4=Error, 5=Critical)    |           |
++----------------------+------------------------------------------------------+-----------+
+| RSTRNT_NOPLUGINS     | Set by restraint to disable some plugin functionality| Restraint |
+|                      | when "task_run" plugins execute. Further details on  |           |
+|                      | this variable can be found :ref:`plugins`.           |           |
++----------------------+------------------------------------------------------+-----------+
+| RSTRNT_PKG_CMD       | These variables are used to control the behavior of  | Default/  |
+| RSTRNT_PKG_ARGS      | the command rstrnt-package.  For more details, refer | User      |
+| RSTRNT_PKG_INSTALL   | to TBD Make reference to rstrnt-package              |           |
+| RSTRNT_PKG_REMOVE    |                                                      |           |
+| RSTRNT_PKG_RETRIES   |                                                      |           |
+| RSTRNT_PKG_DELAY     |                                                      |           |
++----------------------+------------------------------------------------------+-----------+
+| RSTRNT_PLUGINS_DIR   | Specifies the directory to run localwatchdog or      | Restraint |
+|                      | report_result plugins.                               |           |
++----------------------+------------------------------------------------------+-----------+


### PR DESCRIPTION
Users should stop using RHTS extension or RHTS library and use
restraint only.  This changeset documents steps needed to
remove RHTS and lists substitutes for RHTS scripts, variables,
and metadata file.

Bug: 1802610