### PR TITLE
Fix: RSTRNT to create well-known OUTPUTFILE var

### DIFF
--- a/plugins/localwatchdog.d/10_localwatchdog
+++ b/plugins/localwatchdog.d/10_localwatchdog
@@ -3,7 +3,9 @@
 PLUGIN=$(basename $0)
 
 if [ -z $OUTPUTFILE ]; then
+    if [ -s /mnt/testarea/current.log ]; then
         export OUTPUTFILE="/mnt/testarea/current.log"
+    fi
 fi
 
 rstrnt-report-result --no-plugins $TEST/$PLUGIN WARN 0

--- a/plugins/task_run.d/25_environment
+++ b/plugins/task_run.d/25_environment
@@ -8,6 +8,21 @@
 
 rstrnt_info "*** Running Plugin: $0"
 
+if [ -z "$RSTRNT_NOPLUGINS" ]; then
+
+    if [ -z "$OUTPUTFILE" ]; then
+        export OUTPUTFILE=`mktemp /mnt/testarea/tmp.XXXXXX`
+    fi
+
+    if [ -e $OUTPUTFILE ]; then
+        if [ -h /mnt/testarea/current.log ]; then
+                ln -sf $OUTPUTFILE /mnt/testarea/current.log
+        else
+                ln -s $OUTPUTFILE /mnt/testarea/current.log
+        fi
+    fi
+fi
+
 if [ -z "$HOSTNAME" ]; then
    HOSTNAME=$(hostname)
 fi


### PR DESCRIPTION
In order to eliminate dependency of rhts_environment.h, restraint
should create OUTPUTFILE environment variable used by the command
rstrnt-report-result.  This is done once for each task execution
when the user's task is run.  If the local watchdog is executed,
it will see this file and if there is data will report the results.

Bug: 1813946