### PR TITLE
BLOCKED: Report Task Abort Status when Local Watchdog Expires

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -97,6 +97,8 @@ The format of the <server-url> is one of the following depending on the command:
 
     # for rstrnt-abort
       http://localhost:<port>/recipes/<recipe_id>/status/
+    # for rstrnt-abort -t task
+      http://localhost:<port>/recipes/<recipe_id>/tasks/<task_id>/status/
     # for rstrnt-adjust-watchdog
       http://localhost:<port>/recipes/<recipe_id>/watchdog/
     # for rstrnt-report-results
@@ -147,7 +149,8 @@ task as well as subsequent tasks in the recipe will be marked as `aborted` and t
 Arguments for this command are as follows::
 
     rstrnt-abort [ -c, --current [ -i, --pid <server-process-id> ] \
-                   -s, --server <server-url>
+                   -s, --server <server-url> \
+                   -t|--type <task|recipe>
                  ]
 
 Where:
@@ -162,9 +165,15 @@ Where:
 
    Refer to :ref:`common-cmd-args` for details.
 
-   Where <server-url> is as follows::
+   Where <server-url> is one of the following depending on -t|--type option::
 
        http://localhost:<port>/recipes/<recipe_id>/status/
+       http://localhost:<port>/recipes/<recipe_id>/tasks/<task_id>/status/
+
+.. option:: -t|--type <task|recipe>
+
+   To choose whether to abort just the task or the entire recipe. If not specified, the default
+   is aborting the entire recipe as described earlier.
 
 rstrnt-adjust-watchdog
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/plugins/localwatchdog.d/99_reboot
+++ b/plugins/localwatchdog.d/99_reboot
@@ -6,4 +6,5 @@
 PLUGIN=$(basename $0)
 
 rstrnt-report-result --no-plugins $TEST/$PLUGIN WARN 0
+rstrnt-abort -t task
 rstrnt-reboot

--- a/src/cmd_log.c
+++ b/src/cmd_log.c
@@ -25,7 +25,7 @@
 #include "utils.h"
 
 void
-format_log_server(ServerData *s_data)
+format_log_server(ServerData *s_data, GError **error)
 {
     if (s_data->server_recipe && s_data->task_id) {
         s_data->server = g_strdup_printf ("%s/tasks/%s", s_data->server_recipe, s_data->task_id);

--- a/src/cmd_result.c
+++ b/src/cmd_result.c
@@ -85,7 +85,7 @@ void restraint_free_appdata(AppData *app_data)
 }
 
 void
-format_result_server(ServerData *s_data)
+format_result_server(ServerData *s_data, GError **error)
 {
     if (s_data->server_recipe && s_data->task_id) {
         s_data->server = g_strdup_printf ("%s/tasks/%s/results/",

--- a/src/cmd_utils.c
+++ b/src/cmd_utils.c
@@ -57,7 +57,7 @@ get_taskid (void)
 {
     gchar *prefix = NULL;
     gchar *task_id_key = NULL;
-    gchar *task_id= NULL;
+    gchar *task_id = NULL;
 
     prefix = getenv("HARNESS_PREFIX") ? getenv("HARNESS_PREFIX") : "";
     task_id_key = g_strdup_printf ("%sTASKID", prefix);
@@ -198,7 +198,7 @@ get_restraintd_pid (GError **gerror) {
 
 void
 format_server_string(ServerData *s_data,
-                  void (*format_server)(ServerData *s_data),
+                  void (*format_server)(ServerData *s_data, GError **error),
                   GError **error)
 {
 
@@ -213,7 +213,7 @@ format_server_string(ServerData *s_data,
     } else {
         get_env_vars_and_format_ServerData(s_data);
     }
-    format_server(s_data);
+    format_server(s_data, error);
 }
 
 void

--- a/src/cmd_utils.h
+++ b/src/cmd_utils.h
@@ -13,7 +13,7 @@ void clear_server_data(ServerData *s_data);
 void get_env_vars_and_format_ServerData(ServerData *s_data);
 void get_env_vars_from_file(ServerData *s_data, GError **error);
 void format_server_string(ServerData *s_data,
-                       void (*format_server)(ServerData *s_data),
+                       void (*format_server)(ServerData *s_data, GError **error),
                        GError **error);
 void set_envvar_from_file(gint pid, GError **error);
 void unset_envvar_from_file(gint pid, GError **error);

--- a/src/cmd_watchdog.c
+++ b/src/cmd_watchdog.c
@@ -30,7 +30,7 @@
 #include "utils.h"
 
 void
-format_watchdog_server(ServerData *s_data)
+format_watchdog_server(ServerData *s_data, GError **error)
 {
     if (s_data->server_recipe) {
         s_data->server = g_strdup_printf ("%s/watchdog", s_data->server_recipe);

--- a/src/utils.c
+++ b/src/utils.c
@@ -59,7 +59,9 @@ void update_env_script(gchar *prefix, gchar *restraint_url,
     g_fprintf(env_file, "HARNESS_PREFIX=%s\n", prefix);
     g_fprintf(env_file, "%sURL=%s\n", prefix, restraint_url);
     g_fprintf(env_file, "%sRECIPE_URL=%s/recipes/%s\n", prefix, restraint_url, recipe_id);
-    g_fprintf(env_file, "%sTASKID=%s\n", prefix, task_id);
+    if (task_id) {
+        g_fprintf(env_file, "%sTASKID=%s\n", prefix, task_id);
+    }
     fclose(env_file);
 }
 


### PR DESCRIPTION
BLOCKED: Pending performance improvement fixes
When the local watchdog expires, it should report a task status of
Aborted.  Instead it shows Warn which is the last report result state.
Additionally, you should continue to see 10_localwatchdog and
99_reboot plugins in the "Task Result" section of the job.  Once
the machine reboots (due to lwd expire), it should continue onto
the next task.

The purpose of this change is to allow users to identify a failed
test.  Investigating this issue revealed documentation which
says Aborted is the desired result for LWD.  The code also was
leaning towards reporting a status of Aborted. However,
the 99_reboot doesn't allow execution to go back to restraintd
so reporting status of aborted does not complete.

Bug: 1804409