### PR TITLE
Allow to specify restraintd port

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -27,8 +27,8 @@ command to view restraint logs::
  -- Logs begin at Thu 2020-03-12 11:45:05 EDT, end at Thu 2020-03-12 12:10:47 EDT. --
  Mar 12 11:45:26 virt-test systemd[1]: Starting The restraint harness....
  Mar 12 11:45:26 virt-test systemd[1]: Started The restraint harness..
- Mar 12 11:45:26 virt-test restraintd[1135]: recipe: * Fetching recipe: http://labhost.testdomain.com:8000//recipes/30220/
- Mar 12 11:45:26 virt-test restraintd[1135]: Listening on http://localhost:39581
+ Mar 12 11:45:26 virt-test restraintd[1135]: recipe: * Fetching recipe: http://lc.example.net:8000//recipes/30220/
+ Mar 12 11:45:26 virt-test restraintd[1135]: Listening on http://localhost:8081
  Mar 12 11:45:26 virt-test restraintd[1135]: recipe: * Parsing recipe
  Mar 12 11:45:26 virt-test restraintd[1135]: recipe: * Running recipe
  Mar 12 11:45:26 virt-test restraintd[1135]: ** Fetching task: 183853 [/mnt/tests/distribution/check-install]
@@ -40,11 +40,12 @@ command to view restraint logs::
  Mar 12 11:45:33 virt-test restraintd[1135]: ** Updating external watchdog: 2400 seconds
  Mar 12 11:45:33 virt-test restraintd[1135]: ** Installing dependencies
  Mar 12 11:45:33 virt-test restraintd[1135]: ** Running task: 183853 [/distribution/check-install]
- .
- .
- .
+ ...
  Mar 12 11:45:43 virt-test restraintd[1135]: ** Completed Task : 183853
 
+
+When `restraintd` runs as a system service by SysV init or systemd, it
+listens on the port 8081.
 
 The scripts and programs associated with the `restraintd` server can be
 run within the context of a job as well outside a job execution.
@@ -539,7 +540,7 @@ restraint
 
 Used for stand-alone execution.
 
-Use the restraint command to spawn a restraintd server process to run a job on a
+Use the `restraint` command to spawn a `restraintd` process to run a job on a
 remote test machine.  You can run jobs on the local machine but it is not
 recommended since some tasks reboot the system. Hosts are tied to recipe IDs
 inside the job XML.
@@ -582,6 +583,10 @@ A sample of restraint command line is as follows:
 
 .. end
 
+By default, the `restraintd` launched in the remote system will randomly
+choose a free port to listen on. The option ``-p, --port <port>`` can be
+used to specify the port where `restraintd` will listen on.
+
 Restraint will look for the next available directory to store the results in.
 In the above example, it will see if the directory simple_job.01 exists. If
 it does (because of a previous run) it will then look for simple_job.02. It
@@ -600,6 +605,7 @@ By default, Restraint will report the start and stop of each task run like this:
  *  T:   2 [/kernel/misc/gdb-simple                         ] Completed: PASS
  *  T:   3 [restraint/vmstat                                ] Running
  *  T:   3 [restraint/vmstat                                ] Completed
+
 
 All of this information is also stored in the job.xml which in this case is
 stored in the ./simple_job.07 directory.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -120,3 +120,5 @@ For SysV init based systems use the following commands::
  # chkconfig --level 345 restraintd on
  Start the service now
  # service restraintd start
+
+When Restraint runs as a system service it listens on the port 8081.

--- a/init.d/restraintd
+++ b/init.d/restraintd
@@ -9,6 +9,7 @@
 . /etc/rc.d/init.d/functions
 
 prog=restraintd
+restraintd_port=8081
 
 if [ -f /etc/sysconfig/$prog ]; then
     . /etc/sysconfig/$prog
@@ -19,7 +20,7 @@ LOCKFILE=/var/lock/subsys/$prog
 start() {
     check_beaker
     echo -n $"Starting $prog: "
-    daemon --check $prog "bash -c '(( $prog 3>&1 1>&2 2>&3 ) | tee /dev/console ) >> /var/log/restraintd.log 2>&1 &'"
+    daemon --check $prog "bash -c '(( $prog --port $restraintd_port 3>&1 1>&2 2>&3 ) | tee /dev/console ) >> /var/log/restraintd.log 2>&1 &'"
     RETVAL=$?
     echo
     if test $RETVAL = 0; then

--- a/init.d/restraintd.service
+++ b/init.d/restraintd.service
@@ -7,7 +7,7 @@ Requires=network-online.target
 Type=simple
 StandardError=syslog+console
 ExecStartPre=/usr/bin/check_beaker
-ExecStart=/usr/bin/restraintd
+ExecStart=/usr/bin/restraintd --port 8081
 KillMode=process
 OOMScoreAdjust=-1000
 

--- a/src/client.c
+++ b/src/client.c
@@ -1749,8 +1749,6 @@ int main(int argc, char *argv[]) {
             g_free, (GDestroyNotify)&restraint_free_recipe_data);
 
     GOptionEntry entries[] = {
-        { "port", 'p', 0, G_OPTION_ARG_INT, &app_data->restraint_port,
-            "Restraint HTTP server port to listen on", "PORT" },
         { "job", 'j', 0, G_OPTION_ARG_STRING, &job,
             "Run job from file", "FILE" },
         { "run", 'r', 0, G_OPTION_ARG_STRING, &app_data->run_dir,
@@ -1760,8 +1758,10 @@ int main(int argc, char *argv[]) {
         { "host", 't', 0, G_OPTION_ARG_STRING_ARRAY, &hostarr,
             "Set host for a recipe with specific id.",
             "<recipe_id>=[<user>@]<host>" },
-        {"conn-retries", 'c', 0, G_OPTION_ARG_INT, &app_data->max_retries,
+        { "conn-retries", 'c', 0, G_OPTION_ARG_INT, &app_data->max_retries,
             "Specify the number of reconnection retries.", NULL},
+        { "port", 'p', 0, G_OPTION_ARG_INT, &app_data->restraint_port,
+            "Port for restraintd HTTP server", "PORT" },
         { "verbose", 'v', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK,
             callback_parse_verbose, "Increase verbosity, up to three times.",
             NULL },

--- a/src/client.h
+++ b/src/client.h
@@ -64,6 +64,7 @@ typedef struct _AppData {
     guint max_retries;
     gchar *rsh_cmd;
     gchar *restraint_path;
+    guint restraint_port;
 } AppData;
 
 #endif

--- a/src/server.c
+++ b/src/server.c
@@ -583,11 +583,14 @@ int main(int argc, char *argv[]) {
   SoupServer *soup_server = NULL;
   GError *error = NULL;
   GSList *uris;
+  guint port;
+
+  port = 0;
 
   GOptionEntry entries [] = {
-        { "stdin", 's', 0, G_OPTION_ARG_NONE, &app_data->stdin,
-            "Run from STDIN/STDOUT", NULL},
-        { NULL }
+    { "port", 'p', 0, G_OPTION_ARG_INT, &port, "HTTP server port to listen on", "PORT" },
+    { "stdin", 's', 0, G_OPTION_ARG_NONE, &app_data->stdin, "Run from STDIN/STDOUT", NULL },
+    { NULL }
   };
   GOptionContext *context = g_option_context_new(NULL);
   g_option_context_set_summary(context,
@@ -636,9 +639,9 @@ int main(int argc, char *argv[]) {
   soup_server_add_handler (soup_server, "/recipes",
                            server_recipe_callback, app_data, NULL);
 
-  // Tell our soup server to listen on any interface
+  // Tell our soup server to listen on any local interface
   // This includes ipv4 and ipv6 if available.
-  if (!soup_server_listen_local( soup_server, 0, 0, NULL)) {
+  if (!soup_server_listen_local (soup_server, port, 0, NULL)) {
       g_error ("Unable to listen on either ipV4 or ipV6 protocols, exiting...\n");
       exit (FAILED_LISTEN);
   }

--- a/src/server.c
+++ b/src/server.c
@@ -588,7 +588,7 @@ int main(int argc, char *argv[]) {
   port = 0;
 
   GOptionEntry entries [] = {
-    { "port", 'p', 0, G_OPTION_ARG_INT, &port, "HTTP server port to listen on", "PORT" },
+    { "port", 'p', 0, G_OPTION_ARG_INT, &port, "Port to listen on", "PORT" },
     { "stdin", 's', 0, G_OPTION_ARG_NONE, &app_data->stdin, "Run from STDIN/STDOUT", NULL },
     { NULL }
   };


### PR DESCRIPTION
In release 0.2.0 the restraintd port is chosen randomly for each run. Before this release, restraintd used the port 8081 as default, and some workflows, like /distribution/reservesys in beaker-core-tasks, relied on having a static port.

Adding back the option to specify the restraintd port will allow to make the port static when needed, and keep it dynamic when it isn't.

+ Add `-p, --port` option to server and client. If the option is not used, a free port will be chosen randomly
+ Use port 8081 when running restraintd as a system service
+ Add reference to `-p, --port` option and system service port to docs

Closes #28 