### PR TITLE
refactor: Use G_DEFINE_QUARK for errors

### DIFF
--- a/src/errors.c
+++ b/src/errors.c
@@ -1,7 +1,4 @@
-
 #include <glib.h>
+#include "errors.h"
 
-GQuark restraint_error_quark(void) {
-    return g_quark_from_static_string("restraint-error-quark");
-}
-
+G_DEFINE_QUARK (restraint-error-quark, restraint_error);

--- a/src/errors.h
+++ b/src/errors.h
@@ -1,5 +1,9 @@
-#define RESTRAINT_ERROR restraint_error_quark()
-GQuark restraint_error_quark (void);
+#ifndef _RESTRAINT_ERRORS_H
+#define _RESTRAINT_ERRORS_H
+
+#include <glib.h>
+
+#define RESTRAINT_ERROR (restraint_error_quark ())
 
 typedef enum {
     RESTRAINT_PARSE_ERROR_BAD_SYNTAX, /* parse errors */
@@ -22,3 +26,6 @@ typedef enum {
     RESTRAINT_TOO_MANY_RESTRAINTD_RUNNING,
 } RestraintError;
 
+GQuark restraint_error_quark (void);
+
+#endif


### PR DESCRIPTION
As sugested in GLib's error reporting docs.