### PR TITLE
refactor: get_recipe_url and get_taskid

### DIFF
--- a/src/cmd_utils.c
+++ b/src/cmd_utils.c
@@ -14,6 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with Restraint.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include <glib.h>
 #include <gio/gio.h>
 #include <glib/gstdio.h>
@@ -26,45 +27,27 @@
 #include "utils.h"
 #include "cmd_utils.h"
 
-
-/* get_recipe_url
- *
- * To allow 'C' command code to read in some environment variables
- * to acquire current RECIPE_URL.
+/*
+ * Like getenv, but checks for HARNESS_PREFIX
  */
-gchar *
-get_recipe_url ( void )
+const gchar *
+rstrnt_getenv (const gchar *name)
 {
-    gchar *prefix = NULL;
-    gchar *server_recipe_key = NULL;
-    gchar *server_recipe = NULL;
+    const gchar *prefix;
+    const gchar *value;
+    gchar       *long_name;
 
-    prefix = getenv("HARNESS_PREFIX") ? getenv("HARNESS_PREFIX") : "";
-    server_recipe_key = g_strdup_printf ("%sRECIPE_URL", prefix);
-    server_recipe = getenv(server_recipe_key);
-    g_free(server_recipe_key);
+    prefix = g_getenv ("HARNESS_PREFIX");
 
-    return (server_recipe);
-}
+    if (prefix == NULL || strlen (prefix) == 0)
+        return g_getenv (name);
 
-/* get_taskid
- *
- * To allow 'C' command code to read in some environment variables
- * to acquire current TASK_ID.
- */
-gchar *
-get_taskid (void)
-{
-    gchar *prefix = NULL;
-    gchar *task_id_key = NULL;
-    gchar *task_id= NULL;
+    long_name = g_strconcat (prefix, name, NULL);
+    value = g_getenv (long_name);
 
-    prefix = getenv("HARNESS_PREFIX") ? getenv("HARNESS_PREFIX") : "";
-    task_id_key = g_strdup_printf ("%sTASKID", prefix);
-    task_id = getenv(task_id_key);
-    g_free(task_id_key);
+    g_free (long_name);
 
-    return (task_id);
+    return value;
 }
 
 void get_env_vars_and_format_ServerData(ServerData *s_data)

--- a/src/cmd_utils.h
+++ b/src/cmd_utils.h
@@ -1,5 +1,7 @@
-#ifndef CMD_UTILS_H__
-#define CMD_UTILS_H__
+#ifndef _RESTRAINT_CMD_UTILS_H
+#define _RESTRAINT_CMD_UTILS_H
+
+#include <glib.h>
 
 typedef struct {
     guint port;
@@ -7,6 +9,11 @@ typedef struct {
     gchar *server_recipe;
     gchar *task_id;
 } ServerData;
+
+const gchar *rstrnt_getenv (const gchar *name);
+
+#define get_taskid()     ((gchar *) rstrnt_getenv ("TASKID"))
+#define get_recipe_url() ((gchar *) rstrnt_getenv ("RECIPE_URL"))
 
 void clear_server_data(ServerData *s_data);
 void get_env_vars_and_format_ServerData(ServerData *s_data);
@@ -16,8 +23,6 @@ void format_server_string(ServerData *s_data,
                        GError **error);
 void set_envvar_from_file(guint port, GError **error);
 void unset_envvar_from_file(guint port, GError **error);
-gchar *get_taskid (void);
-gchar *get_recipe_url (void);
 
 void cmd_usage(GOptionContext *context);
 

--- a/src/test_cmd_utils.c
+++ b/src/test_cmd_utils.c
@@ -115,11 +115,70 @@ test_get_recipe_url_prefix (void)
     g_assert_cmpstr (recipe_url, ==, expected_recipe_url);
 }
 
+static void
+test_rstrnt_getenv_not_set (void)
+{
+    g_assert_cmpstr (rstrnt_getenv ("NOT_SET_PLEASE"), ==, NULL);
+}
+
+static void
+test_rstrnt_getenv_empty (void)
+{
+    const gchar *value;
+
+    g_setenv ("EMPTY_PLEASE", "", TRUE);
+
+    value = rstrnt_getenv ("EMPTY_PLEASE");
+
+    g_unsetenv ("EMPTY_PLEASE");
+
+    g_assert_cmpstr (value, ==, "");
+}
+
+static void
+test_rstrnt_getenv_set (void)
+{
+    const gchar *value;
+
+    g_setenv ("SOME_VAR", "42", TRUE);
+
+    value = rstrnt_getenv ("SOME_VAR");
+
+    g_unsetenv ("SOME_VAR");
+
+    g_assert_cmpstr (value, ==, "42");
+}
+
+static void
+test_rstrnt_getenv_prefix (void)
+{
+    const gchar *value;
+
+    g_setenv ("HARNESS_PREFIX", "PREFIX_", TRUE);
+    g_setenv ("PREFIX_SOME_VAR", "42", TRUE);
+
+    value = rstrnt_getenv ("SOME_VAR");
+
+    g_unsetenv ("HARNESS_PREFIX");
+    g_unsetenv ("PREFIX_SOME_VAR");
+
+    g_assert_cmpstr (value, ==, "42");
+}
+
 int
 main (int   argc,
       char *argv[])
 {
     g_test_init (&argc, &argv, NULL);
+
+    g_test_add_func ("/cmd_utils/rstrnt_getenv/not_set",
+                     test_rstrnt_getenv_not_set);
+    g_test_add_func ("/cmd_utils/rstrnt_getenv/empty",
+                     test_rstrnt_getenv_empty);
+    g_test_add_func ("/cmd_utils/rstrnt_getenv/set",
+                     test_rstrnt_getenv_set);
+    g_test_add_func ("/cmd_utils/rstrnt_getenv/prefix",
+                     test_rstrnt_getenv_prefix);
 
     g_test_add_func ("/cmd_utils/get_taskid/not_set",
                      test_get_taskid_not_set);

--- a/src/utils.h
+++ b/src/utils.h
@@ -15,8 +15,8 @@
     along with Restraint.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef __UTILS_H
-#define __UTILS_H
+#ifndef _RESTRAINT_UTILS_H
+#define _RESTRAINT_UTILS_H
 
 #include <glib.h>
 #define BASE10 10


### PR DESCRIPTION
Add rstrnt_getenv with the logic for checking HARNESS_PREFIX and replace
get_recipe_url and get_taskid with macros.

Test rstrnt_getenv covering:
- Variable not set
- Variable empty
- Variable set
- Variable set with prefix