### PR TITLE
Replace call to g_error when report signal

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -673,8 +673,9 @@ int main(int argc, char *argv[]) {
   g_main_loop_run (loop);
 
   if (app_data->last_signal != 0) {
-      g_error("restraintd quit on received signal %s\n",
-              strsignal(app_data->last_signal));
+      g_message("restraintd quit on received signal: %s(%u)\n",
+                strsignal(app_data->last_signal),
+                app_data->last_signal);
   }
 
   soup_session_abort(soup_session);


### PR DESCRIPTION
When signals are received and processed, they are now being logged.
However, the g_error call also calls abort which is appearing
in user's log when they run abrt-cli list.  Replace it with
g_message resolves this issue.

Background:  The user was shutting down services which caused the TERMINATE trap
to  get logged which is how restraintd executed abort by way of g_error.

Bug: 1823840