### PR TITLE
Fix: Initialize error field

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -590,7 +590,7 @@ null_log_writer (GLogLevelFlags   log_level,
 static gboolean
 rstrnt_listen_any_local (SoupServer *server, guint port)
 {
-    GError   *error;
+    GError   *error = NULL;
     GSList   *uris;
     gboolean  is_listening;
 


### PR DESCRIPTION
The error field must be initialized to NULL otherwise unpredictability
will occur.

Issue: 48