### PR TITLE
Revert process stdin behavior

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -216,6 +216,8 @@ process_run (const gchar *command,
              gpointer user_data)
 {
     ProcessData *process_data;
+    guint64      timeout;
+
     process_data = g_slice_new0 (ProcessData);
     process_data->localwatchdog = FALSE;
     process_data->command = g_strsplit (command, " ", 0);
@@ -227,15 +229,18 @@ process_run (const gchar *command,
     process_data->user_data = user_data;
     process_data->io = NULL;
     process_data->cancellable = cancellable;
-    guint64 timeout;
-    gssize results_len;
+
+    process_data->fd_in = -1;
+    process_data->fd_out = -1;
 
     if (fflush (stdout) != 0)
         g_warning ("Failed to flush stdout: %s\n", g_strerror (errno));
+
     if (fflush (stderr) != 0)
         g_warning ("Failed to flush stderr: %s\n", g_strerror (errno));
 
     process_data->pid = restraint_fork (&process_data->fd_out, &process_data->fd_in, use_pty);
+
     if (process_data->pid < 0) {
         /* Failed to fork */
         g_set_error (&process_data->error, RESTRAINT_PROCESS_ERROR,
@@ -284,12 +289,11 @@ process_run (const gchar *command,
     }
 
     // close file descriptors on exec.  Should prevent leaking fd's to child processes.
-    if (fcntl (process_data->fd_out, F_SETFD, FD_CLOEXEC) < 0) {
-        g_warning("Failed to set close on exec for fd_out");
-    }
-    if (fcntl (process_data->fd_in, F_SETFD, FD_CLOEXEC) < 0) {
-        g_warning("Failed to set close on exec for fd_in");
-    }
+    if (process_data->fd_out != -1 && fcntl (process_data->fd_out, F_SETFD, FD_CLOEXEC) < 0)
+        g_warning ("Failed to set close on exec for fd_out");
+
+    if (process_data->fd_in != -1 && fcntl (process_data->fd_in, F_SETFD, FD_CLOEXEC) < 0)
+        g_warning ("Failed to set close on exec for fd_in");
 
     // Localwatchdog handler
     if (process_data->max_time < HEARTBEAT) {
@@ -305,14 +309,15 @@ process_run (const gchar *command,
                                                                NULL);
     }
 
-    if (content_size > 0) {
-        results_len = write(process_data->fd_in, content_input, content_size);
-        if (results_len != content_size) {
-            g_warning("Error writing to STDIN: %s", g_strerror (errno));
+    if (process_data->fd_in != -1) {
+        if (content_input != NULL && content_size > 0) {
+            if (write (process_data->fd_in, content_input, content_size) != content_size)
+                g_warning ("Error writing to STDIN: %s", g_strerror (errno));
         }
-    }
 
-    close(process_data->fd_in);
+        close (process_data->fd_in);
+        process_data->fd_in = -1;
+    }
 
     // IO handler
     if (io_callback != NULL) {


### PR DESCRIPTION
The removal of libssh library from Restraint introduced changes in the way that process utilizes stdin. Changes were made to allow Restraint client to pass the job.xml file to `restraintd` through `stdin`.

- `fd_in` is used uninitialized when pty is requested, and close is done on parent stdin FD. This is causing #26 
- stdin for child process is redirected to a pipe instead of `/dev/null`. This is causing #26, although the root cause remains unknown.

Both issues can be addressed redirecting child process stdin to pipe only when content input needs to be passed. This allows restraintd to keep reading from stdin, and keeps stdin behavior during task execution as when libssh was used.

Fixes #24, fixes #26