### PR TITLE
Fix: Revisit restraint commands

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -108,37 +108,38 @@ The format of the <server-url> is one of the following depending on the command:
 **Local Option**
 
 A simpler option is to run the command locally on the host running `restraintd` by
-specifying the following argument(s)::
+specifying the following argument::
 
-    -c, --current [ -i, --pid <server-process-id> ]
+    --port <server-port-id>
 
-This option must be run on the same host running restraint service since the information is derived
-from the local file `/var/lib/restraint/rstrnt-commands-env-<$pid>.sh` (where `$pid` is restraintd
-process id).  As the server progresses through a job, it defines this file based on the current
-task. As a result, the user does not need to gather restraint port number, recipe number, and
-task number in order to construct a URL for a command as this will be generated for you.
+This option can be used on the same host running `restraint` service since the information is derived
+from the local file `/var/lib/restraint/rstrnt-commands-env-<$port>.sh` (where `$port` is the
+port id restraintd listens on).  As the server progresses through a job, it defines this file based
+on the current task. As a result, the user does not need to gather recipe number and task number in
+order to construct a URL for a command as this will be generated for you. The user will need to
+acquire the port number by running linux commands such as `ss -tnlp | grep restraintd` or look
+at the `restraintd` service journal and search for the following line where in this case 8081 is
+the port number::
+
+  Listening on http://localhost:8081
 
 This option has similar effect to doing the following prior to executing the command::
 
-    export $(cat /var/lib/restraint/rstrnt-commands-env-$pid.sh)
+    export $(cat /var/lib/restraint/rstrnt-commands-env-<$port>.sh)
 
-If there is only one instance of restraintd running, the `-p, -pid <server-process-id>` is not
-required.  If there are multiple instances of restraintd running, the command will fail
-and `-i, --pid <server-process-id>` is required to provide the process id of restraint server
-in which the command is targeted.
 
 In conclusion, one of three methods must be used to execute your command.
 The following are examples of each method using the command `rstrnt-abort` as an example::
 
     rstrnt-abort                                                               # Environment Variables method
     rstrnt-abort -s http://localhost:<port>/recipes/<rid>/tasks/<tid>/status/  # Legacy Method
-    rstrnt-abort -c                                                            # Local Method
+    rstrnt-abort --port 8081                                                   # Local Method
 
 .. note::
    1. Replace <port>, <rid>, <tid> with your restraint port id, Recipe id, taskid.
    2. Given these fields change as the job progresses and if you are running the command
       outside the job, the window of opportunity to target the current running task is reduced
-      for the -c option.
+      when using the --port option.
 
 rstrnt-abort
 ~~~~~~~~~~~~
@@ -147,13 +148,13 @@ task as well as subsequent tasks in the recipe will be marked as `aborted` and t
 
 Arguments for this command are as follows::
 
-    rstrnt-abort [ -c, --current [ -i, --pid <server-process-id> ] \
+    rstrnt-abort [ --port <server-port-id> ] \
                    -s, --server <server-url>
                  ]
 
 Where:
 
-.. option:: -c, --current [-i, --pid <server-process-id>]
+.. option:: --port <server-port-id>
    :noindex:
 
    Refer to :ref:`common-cmd-args` for details.
@@ -174,13 +175,13 @@ This command allows you to adjust both the external watchdog and the local watch
 
 The arguments for this command is as follows::
 
-    rstrnt-adjust-watchdog [ -c, --current [ -i, --pid <server-process-id>] \
+    rstrnt-adjust-watchdog [ --port <server-port-id>] \
                              -s, --server <server-url>
                            ] <time>
 
 Where:
 
-.. option:: -c, --current [server-process-id]
+.. option:: --port <server-port-id>
    :noindex:
 
    Refer to :ref:`common-cmd-args` for details.
@@ -329,13 +330,13 @@ previously sent file.
 
 The arguments for this command are as follows::
 
-    rstrnt-report-log [ -c, --current [ -i, --pid <server-process-id>] \
+    rstrnt-report-log [ --port <server-port-id> \
                         -s, --server <server-url> \
                       ] -l, --filename <logfilename>
 
 Where:
 
-.. option:: -c, --current [ -i, --pid <server-process-id> ]
+.. option:: --port <server-port-id>
    :noindex:
 
    Refer to :ref:`common-cmd-args` for details.
@@ -373,7 +374,7 @@ Restraint Reporting Mode
 
 For restraint reporting mode (not --rhts), the format of arguments is as follows::
 
-    rstrnt-report-result [-c, --current [ -i, --pid <server-process-id>] \
+    rstrnt-report-result [--port <server-port-id>] \
                           -s, --server <server-url> \
                           -o, --outputfile <outfilename> \
                           -p, --disable-plugin <plugin-name> --no-plugins] \
@@ -382,7 +383,7 @@ For restraint reporting mode (not --rhts), the format of arguments is as follows
 
 Where:
 
-.. option:: -c, --current [ -i, --pid <server-process-id>]
+.. option:: --port <server-port-id>
    :noindex:
 
    Refer to :ref:`common-cmd-args` for details.
@@ -454,7 +455,7 @@ Where:
     Optional result metric
 
 The legacy mode depends on environment variables being defined as described in
-:ref:`common-cmd-args`.  The options `-s, --server` and `-c, --current` are not
+:ref:`common-cmd-args`.  The options `-s, --server` and `--port` are not
 supported for legacy mode.
 
 Legacy mode looks to see if the environment variable AVC_ERROR is set

--- a/restraint.spec
+++ b/restraint.spec
@@ -119,7 +119,6 @@ Requires:       /bin/hostname
 %endif
 Requires:       coreutils
 Requires:       libselinux-utils
-Requires:       /usr/bin/pgrep
 
 # All RHTS-format task RPMs have an unversioned requirement on rhts-test-env.
 # Therefore restraint-rhts provides a very low version of rhts-test-env so that

--- a/specfiles/restraint-upstream.spec
+++ b/specfiles/restraint-upstream.spec
@@ -35,7 +35,6 @@ Requires(post):		systemd
 Requires(pre):		systemd
 Requires(postun):	systemd
 Requires:		selinux-policy
-Requires:		/usr/bin/pgrep
 
 %description
 restraint harness which can run standalone or with beaker.  when provided a recipe xml it will execute

--- a/src/cmd_abort.c
+++ b/src/cmd_abort.c
@@ -38,10 +38,8 @@ parse_abort_arguments(AbortAppData *app_data, int argc, char *argv[], GError **e
 
 
     GOptionEntry entries[] = {
-        {"current", 'c', G_OPTION_FLAG_NONE, G_OPTION_FLAG_NONE,
-            &app_data->s.curr_set, "Use current recipe/task id", NULL},
-        {"pid", 'i', G_OPTION_FLAG_NONE, G_OPTION_ARG_INT,
-            &app_data->s.pid, "server pid", "PID"},
+        {"port", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_INT,
+            &app_data->s.port, "restraintd port", "PORT"},
         {"server", 's', 0, G_OPTION_ARG_STRING, &app_data->s.server,
             "Server to connect to", "URL" },
         {"type", 't', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &app_data->type,

--- a/src/cmd_log.c
+++ b/src/cmd_log.c
@@ -39,10 +39,8 @@ parse_log_arguments(LogAppData *app_data, int argc, char *argv[], GError **error
     gboolean ret = TRUE;
 
     GOptionEntry entries[] = {
-        {"current", 'c', G_OPTION_FLAG_NONE, G_OPTION_FLAG_NONE,
-            &app_data->s.curr_set, "Use current recipe/task id", NULL},
-        {"pid", 'i', G_OPTION_FLAG_NONE, G_OPTION_ARG_INT,
-            &app_data->s.pid, "server pid", "PID"},
+        {"port", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_INT,
+            &app_data->s.port, "restraintd port", "PORT"},
         {"server", 's', 0, G_OPTION_ARG_STRING, &app_data->s.server,
             "Server to connect to", "URL" },
         { "filename", 'l', 0, G_OPTION_ARG_STRING, &app_data->filename,

--- a/src/cmd_result.c
+++ b/src/cmd_result.c
@@ -117,10 +117,8 @@ gboolean parse_arguments_rstrnt(AppData *app_data, int argc, char *argv[])
     guint positional_arg_count = 0;
 
     GOptionEntry entry[] = {
-        {"current", 'c', G_OPTION_FLAG_NONE, G_OPTION_FLAG_NONE,
-            &app_data->s.curr_set, "Use current recipe/task id", NULL},
-        {"pid", 'i', G_OPTION_FLAG_NONE, G_OPTION_ARG_INT,
-            &app_data->s.pid, "server pid", "PID"},
+        {"port", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_INT,
+            &app_data->s.port, "restraintd port", "PORT"},
         {"server", 's', 0, G_OPTION_ARG_CALLBACK, callback_server,
             "Server to connect to", "URL" },
         { "message", 't', 0, G_OPTION_ARG_STRING, &app_data->result_msg,

--- a/src/cmd_utils.h
+++ b/src/cmd_utils.h
@@ -2,8 +2,7 @@
 #define CMD_UTILS_H__
 
 typedef struct {
-    gboolean curr_set;
-    gint pid;
+    guint port;
     gchar *server;
     gchar *server_recipe;
     gchar *task_id;
@@ -15,11 +14,10 @@ void get_env_vars_from_file(ServerData *s_data, GError **error);
 void format_server_string(ServerData *s_data,
                        void (*format_server)(ServerData *s_data),
                        GError **error);
-void set_envvar_from_file(gint pid, GError **error);
-void unset_envvar_from_file(gint pid, GError **error);
+void set_envvar_from_file(guint pid, GError **error);
+void unset_envvar_from_file(guint pid, GError **error);
 gchar *get_taskid (void);
 gchar *get_recipe_url (void);
-gint get_restraintd_pid(GError **gerror);
 
 void cmd_usage(GOptionContext *context);
 

--- a/src/cmd_watchdog.c
+++ b/src/cmd_watchdog.c
@@ -45,10 +45,8 @@ parse_watchdog_arguments(WatchdogAppData *app_data, int argc, char *argv[], GErr
 
 
     GOptionEntry entries[] = {
-        {"current", 'c', G_OPTION_FLAG_NONE, G_OPTION_FLAG_NONE,
-            &app_data->s.curr_set, "Use current recipe/task id", NULL},
-        {"pid", 'i', G_OPTION_FLAG_NONE, G_OPTION_ARG_INT,
-            &app_data->s.pid, "server pid", "PID"},
+        {"port", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_INT,
+            &app_data->s.port, "restraintd port", "PORT"},
         {"server", 's', 0, G_OPTION_ARG_STRING, &app_data->s.server,
             "Server to connect to", "URL" },
         { NULL }

--- a/src/env.c
+++ b/src/env.c
@@ -73,7 +73,7 @@ static void build_param_var(Param *param, GPtrArray *env) {
     g_ptr_array_add(env, g_strdup_printf("%s=%s", param->name, param->value));
 }
 
-void build_env(gchar *restraint_url, gboolean stdin, Task *task) {
+void build_env(gchar *restraint_url, guint port, Task *task) {
     GPtrArray *env = g_ptr_array_new_with_free_func (g_free);
     GError *error = NULL;
 
@@ -161,8 +161,8 @@ void build_env(gchar *restraint_url, gboolean stdin, Task *task) {
     task->env = env;
     // To make it easy for user's to run restraintd commands, these environment variables
     // need to be made conveniently available to user.
-    update_env_script(ENV_PREFIX, restraint_url, task->recipe->recipe_id, task->task_id,
-                      &error);
+    update_env_file(ENV_PREFIX, restraint_url, task->recipe->recipe_id, task->task_id,
+                    port, &error);
     if (error) {
         g_printerr("%s [%s, %d]\n", error->message,
                 g_quark_to_string(error->domain), error->code);

--- a/src/env.h
+++ b/src/env.h
@@ -17,4 +17,4 @@
 
 #include "task.h"
 
-void build_env(gchar *restraint_url, gboolean stdin, Task *task);
+void build_env(gchar *restraint_url, guint port, Task *task);

--- a/src/server.c
+++ b/src/server.c
@@ -636,12 +636,11 @@ int main(int argc, char *argv[]) {
   SoupServer *soup_server = NULL;
   GError *error = NULL;
   GSList *uris;
-  guint port;
 
-  port = 0;
+  app_data->port = 0;
 
   GOptionEntry entries [] = {
-    { "port", 'p', 0, G_OPTION_ARG_INT, &port, "Port to listen on", "PORT" },
+    { "port", 'p', 0, G_OPTION_ARG_INT, &app_data->port, "Port to listen on", "PORT" },
     { "stdin", 's', 0, G_OPTION_ARG_NONE, &app_data->stdin, "Run from STDIN/STDOUT", NULL },
     { NULL }
   };
@@ -694,7 +693,7 @@ int main(int argc, char *argv[]) {
 
   /* Tell our soup server to listen on any local interface. This includes
      IPv4 and IPv6 if available */
-  if (!rstrnt_listen_any_local (soup_server, port)) {
+  if (!rstrnt_listen_any_local (soup_server, app_data->port)) {
       g_error ("Unable to listen on any IPv4 or IPv6 local address, exiting...\n");
       exit (FAILED_LISTEN);
   }
@@ -702,6 +701,7 @@ int main(int argc, char *argv[]) {
   uris = soup_server_get_uris (soup_server);
   SoupURI *uri = uris->data;
   app_data->restraint_url = g_strdup_printf ("http://localhost:%d", uri->port);
+  app_data->port = uri->port;
   g_print ("Listening on %s\n", app_data->restraint_url);
   g_slist_free (uris);
 

--- a/src/server.h
+++ b/src/server.h
@@ -35,6 +35,7 @@ typedef enum {
 
 typedef struct {
   RecipeSetupState state;
+  guint port;
   guint recipe_handler_id;
   guint task_handler_id;
   gchar *recipe_url;

--- a/src/task.c
+++ b/src/task.c
@@ -1002,7 +1002,7 @@ task_handler (gpointer user_data)
       // If not running in rhts_compat mode it will prepend
       // the variables with ENV_PREFIX.
       g_string_printf(message, "** Updating env vars\n");
-      build_env(app_data->restraint_url, app_data->stdin, task);
+      build_env(app_data->restraint_url, app_data->port, task);
       task->state = TASK_WATCHDOG;
       break;
     case TASK_WATCHDOG:

--- a/src/test_cmd_abort.c
+++ b/src/test_cmd_abort.c
@@ -54,26 +54,25 @@ test_rstrnt_abort_server()
     g_slice_free(AbortAppData, app_data);
 }
 
-/* test restraint abort cmd with short 'c&i' args */
+/* test restraint abort cmd with port */
 #define SHORTARGS_SERVER_STRING "http://localhost:46344/recipes/1/status"
 static void
-test_rstrnt_abort_short_c_and_i()
+test_rstrnt_abort_port()
 {
     GError *error = NULL;
     AbortAppData *app_data = g_slice_new0 (AbortAppData);
-    char *mypid = g_strdup_printf("%d", getpid());
+    guint port = 46344;
 
     char *argv[] = {
         CMD_RSTRNT,
-        "-c",
-        "-i",
-        mypid  // need to use our own pid since we created the file
+        "--port",
+        "46344"
     };
     int argc = sizeof(argv) / sizeof(char*);
 
     // Environment file to be used by --current option
-    update_env_script("RSTRNT_", "http://localhost:46344", "1", "1",
-                      &error);
+    update_env_file("RSTRNT_", "http://localhost:46344", "1", "1",
+                    port, &error);
     g_assert_no_error(error);
 
     gboolean rc = parse_abort_arguments(app_data, argc, argv, &error);
@@ -83,45 +82,10 @@ test_rstrnt_abort_short_c_and_i()
     if (error) {
         g_clear_error(&error);
     }
-    unset_envvar_from_file(getpid(), &error);
+    unset_envvar_from_file(port, &error);
     clear_server_data(&app_data->s);
     g_slice_free(AbortAppData, app_data);
-    g_free(mypid);
-}
-
-/* test restraint abort cmd with long 'current&pid' args */
-#define LONGARGS_SERVER_STRING SHORTARGS_SERVER_STRING
-static void
-test_rstrnt_abort_long_current_and_pid()
-{
-    GError *error = NULL;
-    AbortAppData *app_data = g_slice_new0 (AbortAppData);
-    char *mypid = g_strdup_printf("%d", getpid());
-
-    char *argv[] = {
-        CMD_RSTRNT,
-        "--current",
-        "--pid",
-        mypid    // need to use our own pid since we created the file
-    };
-    int argc = sizeof(argv) / sizeof(char*);
-
-    // Environment file to be used by --current option
-    update_env_script("RSTRNT_", "http://localhost:46344", "1", "1",
-                      &error);
-    g_assert_no_error(error);
-
-    gboolean rc = parse_abort_arguments(app_data, argc, argv, &error);
-    g_assert_true(rc);
-    g_assert_cmpstr(LONGARGS_SERVER_STRING, ==, app_data->s.server);
-
-    if (error) {
-        g_clear_error(&error);
-    }
-    unset_envvar_from_file(getpid(), &error);
-    clear_server_data(&app_data->s);
-    g_slice_free(AbortAppData, app_data);
-    g_free(mypid);
+    remove_env_file(port);
 }
 
 /* test restraint abort cmd using environment vars and not args*/
@@ -130,12 +94,18 @@ static void
 test_environment_variables()
 {
     GError *error = NULL;
+    guint port = 99999;
     AbortAppData *app_data = g_slice_new0 (AbortAppData);
     char *argv[] = {
         CMD_RSTRNT
     };
     int argc = sizeof(argv) / sizeof(char*);
-    set_envvar_from_file(99999, &error);
+
+    // Environment file to be used by environmnet variables
+    update_env_file("RSTRNT_", "http://localhost:99999", "2", "2",
+                    port, &error);
+    g_assert_no_error(error);
+    set_envvar_from_file(port, &error);
     g_assert_no_error(error);
 
     gboolean rc = parse_abort_arguments(app_data, argc, argv, &error);
@@ -145,27 +115,30 @@ test_environment_variables()
     if (error) {
         g_clear_error(&error);
     }
+    unset_envvar_from_file(port, &error);
     clear_server_data(&app_data->s);
     g_slice_free(AbortAppData, app_data);
+    remove_env_file(port);
 
 }
-/* test restraint abort cmd env_file not exist */
+/* test restraint abort cmd port env_file not exist */
 static void
-test_rstrnt_abort_current_file_not_exist()
+test_rstrnt_abort_port_file_not_exist()
 {
     GError *error = NULL;
     AbortAppData *app_data = g_slice_new0 (AbortAppData);
+    guint port = 46344;
+
     char *argv[] = {
         CMD_RSTRNT,
-        "-c",
-        "-i",
-        "11111"   /* does not exist. */
+        "--port",
+        "999"   /* does not exist. */
     };
     int argc = sizeof(argv) / sizeof(char*);
 
     // Environment file to be used by --current option
-    update_env_script("RSTRNT_", "http://localhost:46344", "1", "1",
-                      &error);
+    update_env_file("RSTRNT_", "http://localhost:46344", "1", "1",
+                    port, &error);
     g_assert_no_error(error);
 
     gboolean rc = parse_abort_arguments(app_data, argc, argv, &error);
@@ -173,7 +146,7 @@ test_rstrnt_abort_current_file_not_exist()
     g_assert_error(error, RESTRAINT_ERROR, RESTRAINT_MISSING_FILE);
 
     if (error) {
-        gchar *filename = get_envvar_filename(11111);
+        gchar *filename = get_envvar_filename(999);
         gchar *expect_msg = g_strdup_printf("File %s not present",
                                             filename);
         int rc = g_strcmp0(error->message, expect_msg);
@@ -182,76 +155,27 @@ test_rstrnt_abort_current_file_not_exist()
         g_assert_cmpint(rc, ==, 0);
         g_clear_error(&error);
     }
-    unset_envvar_from_file(getpid(), &error);
+    unset_envvar_from_file(port, &error);
     clear_server_data(&app_data->s);
     g_slice_free(AbortAppData, app_data);
-
-}
-
-
-/* test restraint abort cmd Error Case Failed to get restraintd pid */
-static void
-test_rstrnt_abort_no_restraintd_running()
-{
-    GError *error = NULL;
-    AbortAppData *app_data = g_slice_new0 (AbortAppData);
-    char *argv[] = {
-        CMD_RSTRNT,
-        "-c"
-    };
-    int argc = sizeof(argv) / sizeof(char*);
-
-    // Environment file to be used by --current option
-    update_env_script("RSTRNT_", "http://localhost:46344", "1", "1",
-                      &error);
-    g_assert_no_error(error);
-
-    gboolean rc = parse_abort_arguments(app_data, argc, argv, &error);
-    g_assert_false(rc);
-    g_assert_error(error, RESTRAINT_ERROR,
-                   RESTRAINT_NO_RESTRAINTD_RUNNING_ERROR);
-
-    if (error) {
-        int rc = g_strcmp0(error->message,
-                           "Failed to get restraintd pid. Server not running.");
-        g_assert_cmpint(rc, ==, 0);
-        g_clear_error(&error);
-    }
-    unset_envvar_from_file(getpid(), &error);
-    clear_server_data(&app_data->s);
-    g_slice_free(AbortAppData, app_data);
+    remove_env_file(port);
 
 }
 
 
 int main(int argc, char *argv[])
 {
-    GError *error = NULL;
 
     g_test_init(&argc, &argv, NULL);
-    gchar *oldfilename = get_envvar_filename(getpid());
-    gchar *newfilename = get_envvar_filename(99999);
-
-    // Environment file to be used by environmnet variables
-    update_env_script("RSTRNT_", "http://localhost:99999", "2", "2",
-                      &error);
-    g_assert_no_error(error);
-    g_rename(oldfilename, newfilename);
-    g_free(oldfilename);
-    g_free(newfilename);
 
     g_test_add_func("/cmd_upload/rhts_test_rstrnt_abort_server",
                     test_rstrnt_abort_server);
-    g_test_add_func("/cmd_upload/rhts_test_rstrnt_abort_short_c_and_i",
-                    test_rstrnt_abort_short_c_and_i);
-    g_test_add_func("/cmd_upload/rhts_test_rstrnt_abort_long_current_and_pid",
-                    test_rstrnt_abort_long_current_and_pid);
+    g_test_add_func("/cmd_upload/rhts_test_rstrnt_abort_port",
+                    test_rstrnt_abort_port);
     g_test_add_func("/cmd_upload/rhts_test_environment_variables",
                     test_environment_variables);
-    g_test_add_func("/cmd_upload/rhts_test_rstrnt_abort_current_file_not_exist",
-                    test_rstrnt_abort_current_file_not_exist);
-    g_test_add_func("/cmd_upload/rhts_test_rstrnt_abort_no_restraintd_running",
-                    test_rstrnt_abort_no_restraintd_running);
+    g_test_add_func("/cmd_upload/rhts_test_rstrnt_abort_port_file_not_exist",
+                    test_rstrnt_abort_port_file_not_exist);
 
 
     return g_test_run();

--- a/src/test_cmd_log.c
+++ b/src/test_cmd_log.c
@@ -60,25 +60,24 @@ test_rstrnt_log_server()
 /* test restraint log cmd with short 'c&i' args */
 #define SHORTARGS_SERVER_STRING "http://localhost:46344/recipes/1/tasks/1"
 static void
-test_rstrnt_log_short_c_and_i()
+test_rstrnt_log_port()
 {
     GError *error = NULL;
     LogAppData *app_data = g_slice_new0 (LogAppData);
-    char *mypid = g_strdup_printf("%d", getpid());
+    guint port = 46344;
 
     char *argv[] = {
         CMD_RSTRNT,
-        "-c",
-        "-i",
-        mypid,  // need to use our own pid since we created the file
+        "--port",
+        "46344",
         "-l",
         "LogFile"
     };
     int argc = sizeof(argv) / sizeof(char*);
 
     // Environment file to be used by --current option
-    update_env_script("RSTRNT_", "http://localhost:46344", "1", "1",
-                      &error);
+    update_env_file("RSTRNT_", "http://localhost:46344", "1", "1",
+                    port, &error);
     g_assert_no_error(error);
 
     gboolean rc = parse_log_arguments(app_data, argc, argv, &error);
@@ -88,51 +87,11 @@ test_rstrnt_log_short_c_and_i()
     if (error) {
         g_clear_error(&error);
     }
-    unset_envvar_from_file(getpid(), &error);
+    unset_envvar_from_file(port, &error);
     g_free(app_data->filename);
     clear_server_data(&app_data->s);
     g_slice_free(LogAppData, app_data);
-    g_free(mypid);
-}
-
-/* test restraint log cmd with long 'current&pid' args */
-#define LONGARGS_SERVER_STRING SHORTARGS_SERVER_STRING
-static void
-test_rstrnt_log_long_current_and_pid()
-{
-    GError *error = NULL;
-    LogAppData *app_data = g_slice_new0 (LogAppData);
-    char *mypid = g_strdup_printf("%d", getpid());
-
-    char *argv[] = {
-        CMD_RSTRNT,
-        "--current",
-        "--pid",
-        mypid,   // need to use our own pid since we created the file
-        "-l",
-        "LogFile"
-    };
-    int argc = sizeof(argv) / sizeof(char*);
-
-    // Environment file to be used by --current option
-    update_env_script("RSTRNT_", "http://localhost:46344", "1", "1",
-                      &error);
-    g_assert_no_error(error);
-
-    gboolean rc = parse_log_arguments(app_data, argc, argv, &error);
-    g_assert_true(rc);
-    g_assert_cmpstr(LONGARGS_SERVER_STRING, ==, app_data->s.server);
-
-    if (error) {
-        g_clear_error(&error);
-    }
-    unset_envvar_from_file(getpid(), &error);
-    if (app_data->filename) {
-        g_free(app_data->filename);
-    }
-    clear_server_data(&app_data->s);
-    g_slice_free(LogAppData, app_data);
-    g_free(mypid);
+    remove_env_file(port);
 }
 
 /* test restraint log cmd using environment vars and not args*/
@@ -148,7 +107,13 @@ test_log_environment_variables()
         "LogFile"
     };
     int argc = sizeof(argv) / sizeof(char*);
-    set_envvar_from_file(99999, &error);
+    guint port = 99999;
+
+    // Environment file to be used by environmnet variables
+    update_env_file("RSTRNT_", "http://localhost:99999", "2", "2",
+                    port, &error);
+    g_assert_no_error(error);
+    set_envvar_from_file(port, &error);
     g_assert_no_error(error);
 
     gboolean rc = parse_log_arguments(app_data, argc, argv, &error);
@@ -161,30 +126,31 @@ test_log_environment_variables()
     if (app_data->filename) {
         g_free(app_data->filename);
     }
+    unset_envvar_from_file(port, &error);
     clear_server_data(&app_data->s);
     g_slice_free(LogAppData, app_data);
-
+    remove_env_file(port);
 }
 
 /* test restraint log cmd using environment vars and not args*/
 static void
-test_log_current_file_not_exist()
+test_log_port_file_not_exist()
 {
     GError *error = NULL;
     LogAppData *app_data = g_slice_new0 (LogAppData);
     char *argv[] = {
         CMD_RSTRNT,
-        "-c",
-        "-i",
+        "--port",
         "11111",   /* does not exist. */
         "-l",
         "LogFile"
     };
+    guint port = 46344;
     int argc = sizeof(argv) / sizeof(char*);
 
     // Environment file to be used by --current option
-    update_env_script("RSTRNT_", "http://localhost:46344", "1", "1",
-                      &error);
+    update_env_file("RSTRNT_", "http://localhost:46344", "1", "1",
+                    port, &error);
     g_assert_no_error(error);
 
     gboolean rc = parse_log_arguments(app_data, argc, argv, &error);
@@ -201,78 +167,27 @@ test_log_current_file_not_exist()
         g_assert_cmpint(rc, ==, 0);
         g_clear_error(&error);
     }
-    unset_envvar_from_file(getpid(), &error);
+    unset_envvar_from_file(port, &error);
     if (app_data->filename) {
         g_free(app_data->filename);
     }
     clear_server_data(&app_data->s);
     g_slice_free(LogAppData, app_data);
-
-}
-
-/* test restraint log cmd Error Case Failed to get restraintd pid */
-static void
-test_rstrnt_log_no_restraintd_running()
-{
-    GError *error = NULL;
-    LogAppData *app_data = g_slice_new0 (LogAppData);
-    char *argv[] = {
-        CMD_RSTRNT,
-        "-c",
-        "40h"
-    };
-    int argc = sizeof(argv) / sizeof(char*);
-
-    // Environment file to be used by --current option
-    update_env_script("RSTRNT_", "http://localhost:46344", "1", "1",
-                      &error);
-    g_assert_no_error(error);
-
-    gboolean rc = parse_log_arguments(app_data, argc, argv, &error);
-    g_assert_false(rc);
-    g_assert_error(error, RESTRAINT_ERROR,
-                   RESTRAINT_NO_RESTRAINTD_RUNNING_ERROR);
-
-    if (error) {
-        int rc = g_strcmp0(error->message,
-                           "Failed to get restraintd pid. Server not running.");
-        g_assert_cmpint(rc, ==, 0);
-        g_clear_error(&error);
-    }
-    unset_envvar_from_file(getpid(), &error);
-    clear_server_data(&app_data->s);
-    g_slice_free(LogAppData, app_data);
-
+    remove_env_file(port);
 }
 
 int main(int argc, char *argv[])
 {
-    GError *error = NULL;
-
     g_test_init(&argc, &argv, NULL);
-    gchar *oldfilename = get_envvar_filename(getpid());
-    gchar *newfilename = get_envvar_filename(99999);
-
-    // Environment file to be used by environmnet variables
-    update_env_script("RSTRNT_", "http://localhost:99999", "2", "2",
-                      &error);
-    g_assert_no_error(error);
-    g_rename(oldfilename, newfilename);
-    g_free(oldfilename);
-    g_free(newfilename);
 
     g_test_add_func("/cmd_upload/rhts_test_rstrnt_log_server",
                     test_rstrnt_log_server);
-    g_test_add_func("/cmd_upload/rhts_test_rstrnt_log_short_c_and_i",
-                    test_rstrnt_log_short_c_and_i);
-    g_test_add_func("/cmd_upload/rhts_test_rstrnt_log_long_current_and_pid",
-                    test_rstrnt_log_long_current_and_pid);
+    g_test_add_func("/cmd_upload/rhts_test_rstrnt_log_port",
+                    test_rstrnt_log_port);
     g_test_add_func("/cmd_upload/rhts_test_log_environment_variables",
                     test_log_environment_variables);
-    g_test_add_func("/cmd_upload/rhts_test_log_current_file_not_exist",
-                    test_log_current_file_not_exist);
-    g_test_add_func("/cmd_upload/rhts_test_rstrnt_log_no_restraintd_running",
-                    test_rstrnt_log_no_restraintd_running);
+    g_test_add_func("/cmd_upload/rhts_test_log_port_file_not_exist",
+                    test_log_port_file_not_exist);
 
     return g_test_run();
 }

--- a/src/test_cmd_utils.c
+++ b/src/test_cmd_utils.c
@@ -4,113 +4,6 @@
 #include "errors.h"
 
 static void
-test_get_restraintd_pid_success (void)
-{
-    gchar  *path_bkp;
-    gint    restraintd_pid;
-    GError *error;
-
-    path_bkp = g_strdup (g_getenv ("PATH"));
-    g_setenv ("PATH", "./test-dummies/cmd_utils/bin", TRUE);
-
-    g_setenv ("MOCK_PGREP_STDOUT", "123", TRUE);
-    g_setenv ("MOCK_PGREP_EXIT", "0", TRUE);
-
-    error = NULL;
-
-    restraintd_pid = get_restraintd_pid (&error);
-
-    g_setenv ("PATH", path_bkp, TRUE);
-
-    g_unsetenv ("MOCK_PGREP_STDOUT");
-    g_unsetenv ("MOCK_PGREP_EXIT");
-
-    g_assert_no_error (error);
-    g_assert_cmpint (restraintd_pid, ==, 123);
-
-    g_free (path_bkp);
-}
-
-static void
-test_get_restraintd_pid_many_pids (void)
-{
-    GError *error;
-    gchar  *expected_regex;
-    gchar  *path_bkp;
-    gint    restraintd_pid;
-
-    path_bkp = g_strdup (g_getenv ("PATH"));
-    g_setenv ("PATH", "./test-dummies/cmd_utils/bin", TRUE);
-
-    g_setenv ("MOCK_PGREP_STDOUT", "123 124 125", TRUE);
-    g_setenv ("MOCK_PGREP_EXIT", "0", TRUE);
-
-    expected_regex = "Due to multiple restraintd .+";
-
-    error = NULL;
-
-    restraintd_pid = get_restraintd_pid (&error);
-
-    g_setenv ("PATH", path_bkp, TRUE);
-
-    g_unsetenv ("MOCK_PGREP_STDOUT");
-    g_unsetenv ("MOCK_PGREP_EXIT");
-
-    g_assert_cmpint (restraintd_pid, ==, 0);
-    g_assert_error (error, RESTRAINT_ERROR, RESTRAINT_TOO_MANY_RESTRAINTD_RUNNING);
-    g_assert_true (g_regex_match_simple (expected_regex, error->message, 0, 0));
-
-    g_clear_error (&error);
-    g_free (path_bkp);
-}
-
-static void
-test_get_restraintd_pid_spawn_fail (void)
-{
-    GError *error;
-    gchar  *expected_msg_regex;
-    gchar  *path_bkp;
-    gint    restraintd_pid;
-
-    expected_msg_regex = "Failed to spawn command: .+";
-
-    path_bkp = g_strdup (g_getenv ("PATH"));
-    g_setenv ("PATH", "", TRUE);
-
-    error = NULL;
-
-    restraintd_pid = get_restraintd_pid (&error);
-
-    g_setenv ("PATH", path_bkp, TRUE);
-
-    g_assert_cmpint (restraintd_pid, ==, 0);
-    g_assert_error (error, RESTRAINT_ERROR, RESTRAINT_CMDLINE_ERROR);
-    g_assert_true (g_regex_match_simple (expected_msg_regex, error->message, 0, 0));
-
-    g_clear_error (&error);
-    g_free (path_bkp);
-}
-
-static void
-test_get_restraintd_pid_no_restraintd (void)
-{
-    GError *error;
-    gint    restraintd_pid;
-
-    error = NULL;
-
-    /* Hopefully, there is no restraintd on the system running the tests.
-     * TODO: This should be mocked too. */
-    restraintd_pid = get_restraintd_pid (&error);
-
-    g_assert_cmpint (restraintd_pid, ==, 0);
-    g_assert_error (error, RESTRAINT_ERROR, RESTRAINT_NO_RESTRAINTD_RUNNING_ERROR);
-    g_assert_cmpstr (error->message, ==, "Failed to get restraintd pid. Server not running.");
-
-    g_clear_error (&error);
-}
-
-static void
 test_get_taskid_set (void)
 {
     gchar *task_id;
@@ -245,15 +138,6 @@ main (int   argc,
                      test_get_recipe_url_set);
     g_test_add_func ("/cmd_utils/get_recipe_url/prefix",
                      test_get_recipe_url_prefix);
-
-    g_test_add_func ("/cmd_utils/get_restraintd_pid/success",
-                     test_get_restraintd_pid_success);
-    g_test_add_func ("/cmd_utils/get_restraintd_pid/many_pids",
-                     test_get_restraintd_pid_many_pids);
-    g_test_add_func ("/cmd_utils/get_restraintd_pid/spawn_fail",
-                     test_get_restraintd_pid_spawn_fail);
-    g_test_add_func ("/cmd_utils/get_restraintd_pid/no_restraintd",
-                     test_get_restraintd_pid_no_restraintd);
 
     return g_test_run ();
 }

--- a/src/test_env.c
+++ b/src/test_env.c
@@ -41,12 +41,13 @@ static void test_task_env_role_members_standalone(void)
   Task *task = g_slice_new0(Task);
   Param rmem = {"RECIPE_MEMBERS", "otherhost localhost"};
   gchar *rmembers = NULL;
+  guint port = 1111;
 
   task->rhts_compat = FALSE;
   task->recipe = g_slice_new0(Recipe);
   task->params = g_list_append(task->params, &rmem);
 
-  build_env("http://localhost", FALSE, task);
+  build_env("http://localhost", port, task);
   g_ptr_array_foreach(task->env, (GFunc)get_env_rmembers, &rmembers);
 
   g_assert_cmpstr(rmembers, ==, "otherhost localhost");
@@ -58,6 +59,7 @@ static void test_task_env_role_members_standalone(void)
   }
   g_list_free(task->params);
   g_slice_free(Task, task);
+  remove_env_file(port);
 
   if (rmembers != NULL) {
     g_free(rmembers);
@@ -69,6 +71,7 @@ static void test_task_env_role_members_beaker(void)
   Task *task = g_slice_new0(Task);
   GList *roles = NULL;
   gchar *rmembers = NULL;
+  guint port = 1111;
 
   Role srv = { "SERVERS", "localhost" };
   Role clt = { "CLIENTS", "otherhost" };
@@ -82,7 +85,7 @@ static void test_task_env_role_members_beaker(void)
   task->recipe = g_slice_new0(Recipe);
   task->roles = roles;
 
-  build_env("http://localhost", FALSE, task);
+  build_env("http://localhost", port, task);
   g_ptr_array_foreach(task->env, (GFunc)get_env_rmembers, &rmembers);
 
   g_assert_cmpstr(rmembers, ==, "otherhost localhost");
@@ -95,6 +98,7 @@ static void test_task_env_role_members_beaker(void)
     g_ptr_array_free(task->env, TRUE);
   }
   g_slice_free(Task, task);
+  remove_env_file(port);
 
   if (rmembers != NULL) {
     g_free(rmembers);

--- a/src/utils.h
+++ b/src/utils.h
@@ -22,12 +22,13 @@
 #define BASE10 10
 
 #define CMD_ENV_DIR "/var/lib/restraint"
-#define CMD_ENV_FILE_FORMAT "%s/rstrnt-commands-env-%d.sh"
+#define CMD_ENV_FILE_FORMAT "%s/rstrnt-commands-env-%u.sh"
 
-void update_env_script(gchar *prefix, gchar *restraint_url,
-                       gchar *recipe_id, gchar *task_id,
-                       GError **error);
-gchar *get_envvar_filename(gint pid);
+void update_env_file(gchar *prefix, gchar *restraint_url,
+                     gchar *recipe_id, gchar *task_id,
+                     guint port, GError **error);
+void remove_env_file(guint port);
+gchar *get_envvar_filename(guint port);
 guint64 parse_time_string (gchar *time_string, GError **error);
 gboolean file_exists (gchar *filename);
 gchar *get_package_version(gchar *pkg_name, GError **error);


### PR DESCRIPTION
There are some issues with including call to pidof and pgrep from
restraint commands.  To eliminate OS calls, we must eliminate the
new argument option -c|--current.  Also -i|--pid was associated with
this option and it is replaced with --port.

Issue #51, Issue #44