### PR TITLE
fix: Replace calls to g_error

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -1,4 +1,4 @@
-/*  
+/*
     This file is part of Restraint.
 
     Restraint is free software: you can redistribute it and/or modify
@@ -262,9 +262,10 @@ process_run (const gchar *command,
 
         /* Spawn the command */
         if (execvp (*process_data->command, (gchar **) process_data->command) == -1) {
-            g_error ("Failed to exec() %s, %s error:%s\n",
+            g_warning ("Failed to exec() %s, %s error:%s\n",
                        *process_data->command,
-                       process_data->path, g_strerror (errno));
+                       process_data->path,
+                       g_strerror (errno));
             exit (SPAWN_COMMAND_FAILED);
         }
     }

--- a/src/server.c
+++ b/src/server.c
@@ -666,9 +666,11 @@ int main(int argc, char *argv[]) {
   }
 
   if (error) {
-      g_error ("%s [%s, %d]\n", error->message,
-                  g_quark_to_string (error->domain), error->code);
-      g_clear_error(&error);
+      g_printerr ("%s [%s, %d]\n",
+                  error->message,
+                  g_quark_to_string (error->domain),
+                  error->code);
+      g_clear_error (&error);
       exit (FAILED_GET_CONFIG_FILE);
   }
 
@@ -694,7 +696,7 @@ int main(int argc, char *argv[]) {
   /* Tell our soup server to listen on any local interface. This includes
      IPv4 and IPv6 if available */
   if (!rstrnt_listen_any_local (soup_server, app_data->port)) {
-      g_error ("Unable to listen on any IPv4 or IPv6 local address, exiting...\n");
+      g_printerr ("Unable to listen on any IPv4 or IPv6 local address, exiting...\n");
       exit (FAILED_LISTEN);
   }
 
@@ -710,7 +712,7 @@ int main(int argc, char *argv[]) {
   g_unix_signal_add (SIGHUP, on_sighup_term, app_data);
   int r = prctl(PR_SET_PDEATHSIG, SIGHUP);
   if (r == -1) {
-     g_error ("Unable to set Parent Death Signal to SIGHUP: %s\n", g_strerror (errno));
+     g_printerr ("Unable to set Parent Death Signal to SIGHUP: %s\n", g_strerror (errno));
      exit (FAILED_SET_PDEATHSIG);
   }
 
@@ -743,4 +745,3 @@ int main(int argc, char *argv[]) {
 
   return 0;
 }
-

--- a/src/task.c
+++ b/src/task.c
@@ -219,7 +219,7 @@ io_callback (GIOChannel *io, GIOCondition condition, const gchar *logpath, gpoin
             return G_SOURCE_CONTINUE;
 
           case G_IO_STATUS_ERROR:
-             g_error("IO error: %s", tmp_error->message);
+             g_warning ("IO error: %s", tmp_error->message);
              g_clear_error (&tmp_error);
              return G_SOURCE_REMOVE;
 


### PR DESCRIPTION
Calls to g_error result in core dump and they are not intended to report expected errors.

Replace calls to g_error with g_warning and g_printerr. The later is preferred for reporting to the command line.

Closes #53 