### PR TITLE
Fix: Address comments on command pull 52

### DIFF
--- a/src/cmd_abort.c
+++ b/src/cmd_abort.c
@@ -39,7 +39,7 @@ parse_abort_arguments(AbortAppData *app_data, int argc, char *argv[], GError **e
 
     GOptionEntry entries[] = {
         {"port", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_INT,
-            &app_data->s.port, "restraintd port", "PORT"},
+            &app_data->s.port, "restraintd port number (Service default: 8081)", "PORT"},
         {"server", 's', 0, G_OPTION_ARG_STRING, &app_data->s.server,
             "Server to connect to", "URL" },
         {"type", 't', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &app_data->type,
@@ -49,7 +49,7 @@ parse_abort_arguments(AbortAppData *app_data, int argc, char *argv[], GError **e
 
     GOptionContext *context = g_option_context_new(NULL);
     g_option_context_set_summary(context,
-            "Aborts currently running task. if you don't specify --current or \n"
+            "Aborts currently running task. if you don't specify --port or \n"
             "the server url you must have RECIPE_URL defined.\n"
             "If HARNESS_PREFIX is defined then the value of that must be\n"
             "prefixed to RECIPE_URL");

--- a/src/cmd_log.c
+++ b/src/cmd_log.c
@@ -40,7 +40,7 @@ parse_log_arguments(LogAppData *app_data, int argc, char *argv[], GError **error
 
     GOptionEntry entries[] = {
         {"port", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_INT,
-            &app_data->s.port, "restraintd port", "PORT"},
+            &app_data->s.port, "restraintd port number (Service default: 8081)", "PORT"},
         {"server", 's', 0, G_OPTION_ARG_STRING, &app_data->s.server,
             "Server to connect to", "URL" },
         { "filename", 'l', 0, G_OPTION_ARG_STRING, &app_data->filename,
@@ -54,7 +54,7 @@ parse_log_arguments(LogAppData *app_data, int argc, char *argv[], GError **error
 
     GOptionContext *context = g_option_context_new(NULL);
     g_option_context_set_summary(context,
-            "Report results to lab controller. if you don't specify --current or the\n"
+            "Report results to lab controller. if you don't specify --port or the\n"
             "the server url you must have RECIPE_URL and TASKID defined.\n"
             "If HARNESS_PREFIX is defined then the value of that must be\n"
             "prefixed to RECIPE_URL and TASKID");

--- a/src/cmd_result.c
+++ b/src/cmd_result.c
@@ -118,7 +118,7 @@ gboolean parse_arguments_rstrnt(AppData *app_data, int argc, char *argv[])
 
     GOptionEntry entry[] = {
         {"port", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_INT,
-            &app_data->s.port, "restraintd port", "PORT"},
+            &app_data->s.port, "restraintd port number (Service default: 8081)", "PORT"},
         {"server", 's', 0, G_OPTION_ARG_CALLBACK, callback_server,
             "Server to connect to", "URL" },
         { "message", 't', 0, G_OPTION_ARG_STRING, &app_data->result_msg,
@@ -142,7 +142,7 @@ gboolean parse_arguments_rstrnt(AppData *app_data, int argc, char *argv[])
     g_option_group_add_entries(option_group, entry);
     context = g_option_context_new("TASK_PATH RESULT [SCORE]");
     g_option_context_set_summary(context,
-            "Report results to lab controller. if you don't specify --current or\n"
+            "Report results to lab controller. if you don't specify --port or\n"
             "the server url you must have RECIPE_URL and TASKID defined.\n"
             "If HARNESS_PREFIX is defined then the value of that must be\n"
             "prefixed to RECIPE_URL and TASKID");

--- a/src/cmd_utils.h
+++ b/src/cmd_utils.h
@@ -14,8 +14,8 @@ void get_env_vars_from_file(ServerData *s_data, GError **error);
 void format_server_string(ServerData *s_data,
                        void (*format_server)(ServerData *s_data),
                        GError **error);
-void set_envvar_from_file(guint pid, GError **error);
-void unset_envvar_from_file(guint pid, GError **error);
+void set_envvar_from_file(guint port, GError **error);
+void unset_envvar_from_file(guint port, GError **error);
 gchar *get_taskid (void);
 gchar *get_recipe_url (void);
 

--- a/src/cmd_watchdog.c
+++ b/src/cmd_watchdog.c
@@ -46,7 +46,7 @@ parse_watchdog_arguments(WatchdogAppData *app_data, int argc, char *argv[], GErr
 
     GOptionEntry entries[] = {
         {"port", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_INT,
-            &app_data->s.port, "restraintd port", "PORT"},
+            &app_data->s.port, "restraintd port number (Service default: 8081)", "PORT"},
         {"server", 's', 0, G_OPTION_ARG_STRING, &app_data->s.server,
             "Server to connect to", "URL" },
         { NULL }
@@ -54,7 +54,7 @@ parse_watchdog_arguments(WatchdogAppData *app_data, int argc, char *argv[], GErr
 
     GOptionContext *context = g_option_context_new("<time>");
     g_option_context_set_summary(context,
-            "Adjust watchdog on lab controller. if you don't specify --current or \n"
+            "Adjust watchdog on lab controller. if you don't specify --port or \n"
             "the server url you must have RECIPE_URL defined.\n"
             "If HARNESS_PREFIX is defined then the value of that must be\n"
             "prefixed to RECIPE_URL");


### PR DESCRIPTION
Pull # 52 was merged too early missing comments from peers.  This
changeset addresses those comments. The changes include:

* Update docs for --port option in restraint commands
* Remove references to --current in commands context summary
* Reference restraintd service default port in --port option description
* Improve test_environment_file

Fixes: #51, Fixes #44