### PR TITLE
Revert logging in task io callback

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -214,7 +214,10 @@ io_callback (GIOChannel *io, GIOCondition condition, const gchar *logpath, gpoin
         switch (g_io_channel_read_chars(io, buf, 10000, &bytes_read, &tmp_error)) {
           case G_IO_STATUS_NORMAL:
             /* Push data to our connections.. */
-            g_debug ("%s", buf);
+
+            if (fwrite (buf, sizeof (gchar), bytes_read, stdout) != bytes_read)
+                g_warning ("failed to write message");
+
             connections_write(app_data, logpath, buf, bytes_read);
             return G_SOURCE_CONTINUE;
 

--- a/src/task.c
+++ b/src/task.c
@@ -227,7 +227,7 @@ io_callback (GIOChannel *io, GIOCondition condition, const gchar *logpath, gpoin
              return G_SOURCE_REMOVE;
 
           case G_IO_STATUS_EOF:
-             g_message("finished!");
+             g_print ("finished!");
              return G_SOURCE_REMOVE;
 
           case G_IO_STATUS_AGAIN:


### PR DESCRIPTION
These changes are inline with the recent ones in server_io_callback, #45, to revert logging behavior to the one in restraint-0.1.45.

- Fix incorrect use of buffer. g_debug is replaced with fwrite.
- Replace g_message with g_print

Relates to #12 