### PR TITLE
Introduce Reno for creating release notes

### DIFF
--- a/docs/develop.rst
+++ b/docs/develop.rst
@@ -66,3 +66,6 @@ Submitting a Patch
 
 All patches are submitted using GitHub Pull Requests feature.
 To do that you have to have the fork of the Restraint.
+
+Created patch should also have a note for release notes.
+The note has to be created by `Reno <https://docs.openstack.org/reno/latest/user/usage.html>`__.

--- a/reno.yaml
+++ b/reno.yaml
@@ -1,0 +1,62 @@
+---
+release_tag_re: restraint-((?:v?[\d.ab]|rc)+)
+earliest_version: restraint-0.2.1
+sections:
+  - [features, "What’s New"]
+  - [issues, Known Issues]
+  - [fixes, Bug Fixes]
+  - [api, API Changes]
+  - [deprecations, Deprecation]
+  - [upgrade, Urgent Upgrade Notes]
+  - [other, Other Notable Changes]
+template: |
+  prelude: >
+      Replace this text with content to appear at the top of the section for this
+      release. All of the prelude content is merged together and then rendered
+      separately from the items listed in other parts of the file, so the text
+      needs to be worded so that both the prelude and the other items make sense
+      when read independently. This may mean repeating some details. Not every
+      release note requires a prelude. Usually only notes describing major
+      features or adding release theme details should have a prelude.
+  features:
+    - |
+      List new features here, or remove this section.  All of the list items in
+      this section are combined when the release notes are rendered, so the text
+      needs to be worded so that it does not depend on any information only
+      available in another section, such as the prelude. This may mean repeating
+      some details.
+  issues:
+    - |
+      List known issues here, or remove this section.  All of the list items in
+      this section are combined when the release notes are rendered, so the text
+      needs to be worded so that it does not depend on any information only
+      available in another section, such as the prelude. This may mean repeating
+      some details.
+  upgrade:
+    - |
+      List upgrade notes here, or remove this section.  All of the list items in
+      this section are combined when the release notes are rendered, so the text
+      needs to be worded so that it does not depend on any information only
+      available in another section, such as the prelude. This may mean repeating
+      some details.
+  deprecations:
+    - |
+      List deprecations notes here, or remove this section.  All of the list
+      items in this section are combined when the release notes are rendered, so
+      the text needs to be worded so that it does not depend on any information
+      only available in another section, such as the prelude. This may mean
+      repeating some details.
+  fixes:
+    - |
+      Add normal bug fixes here, or remove this section.  All of the list items
+      in this section are combined when the release notes are rendered, so the
+      text needs to be worded so that it does not depend on any information only
+      available in another section, such as the prelude. This may mean repeating
+      some details.
+  other:
+    - |
+      Add other notes here, or remove this section.  All of the list items in
+      this section are combined when the release notes are rendered, so the text
+      needs to be worded so that it does not depend on any information only
+      available in another section, such as the prelude. This may mean repeating
+      some details.


### PR DESCRIPTION
At this point release notes are managed manually and some of has to manually go thru all issues and list it together and figure out what was the point of the fix. This is really inflexible if we take the time to make another release.

Instead of that, we can use the tool [Reno](https://docs.openstack.org/reno/latest/).
A person who is created patch will also create a small description of the patch.

To create boilerplate user should use
```bash
$ reno new slug-goes-here
```
Output:
```bash
Created new notes file in releasenotes/notes/slug-goes-here-95915aaedd3c48d8.yaml
```

or
```bash
$ tox -e venv -- reno new slug-goes-here
```
Output:
```
venv develop-inst-nodeps: /mnt/projects/release-notes-generation/reno
venv runtests: commands[0] | reno new slug-goes-here
Created new notes file in releasenotes/notes/slug-goes-here-95915aaedd3c48d8.yaml
  venv: commands succeeded
  congratulations :)
```

Then the user can open note in favorite editor and edit content.
During the release all notes are combined together to one release notes.

Fixes: #15 


Signed-off-by: Martin Styk <mastyk@redhat.com>