### PR TITLE
Update container provision scripts

### DIFF
--- a/containers/provision/centos:8.sh
+++ b/containers/provision/centos:8.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+dnf install -y 'dnf-command(config-manager)' \
+	       'dnf-command(builddep)' \
+	       make \
+	       rpm-build \
+	       valgrind \
+	       git-daemon \
+	       python3-flask \
+	       python3-requests \
+	       python3-pytest \
+	       python3-six
+
+dnf config-manager -y --enable PowerTools
+
+dnf install -y $(rpmspec -D "_without_static ''"  --buildrequires -q /restraint/restraint.spec)

--- a/containers/provision/fedora:30.sh
+++ b/containers/provision/fedora:30.sh
@@ -1,1 +1,0 @@
-fedora:latest.sh

--- a/containers/provision/fedora:latest.sh
+++ b/containers/provision/fedora:latest.sh
@@ -6,7 +6,6 @@ dnf -y install 'dnf-command(builddep)' \
 	python3-flask \
 	python3-requests \
 	python3-pytest \
-	python3-six \
-	procps-ng
+	python3-six
 
 dnf -y builddep --spec /restraint/specfiles/restraint-upstream.spec


### PR DESCRIPTION
- Add CentOS 8
- Remove Fedora 30
- Remove procps-ng package from Fedora provision scripts