### PR TITLE
Fix: Resolve loop in local watchdog plugin for non-rhts restraint pac…

### DIFF
--- a/plugins/localwatchdog.d/20_sysinfo
+++ b/plugins/localwatchdog.d/20_sysinfo
@@ -25,11 +25,11 @@ function WatchFile ()
         fi
         diff=$(diff -q $FILE $TMPFILE)
         rc=$?
-        if [ $rc != 0 ]; then
+        if [ $rc == 1 ]; then
             cat $FILE > $TMPFILE
         else
             rm $TMPFILE
-            return 0
+            return $rc
         fi
         sleep 2
     done
@@ -43,8 +43,12 @@ function SysRq ()
     echo $ACTION > /proc/sysrq-trigger
     # Wait until logfile has changed.
     WatchFile $LOGFILE
+    if [[ $? -ne 0 ]]; then
+        logger -p local2.warning -t "List of $ACTION Tasks" Check on $LOGFILE failed
+    fi
 
     logger -p local2.info -t "List of $ACTION Tasks" Stop
+
 }
 
 # Verbose tree view of running processes:

--- a/releasenotes/notes/lwd-loop-4d999551d1e0638c.yaml
+++ b/releasenotes/notes/lwd-loop-4d999551d1e0638c.yaml
@@ -1,0 +1,9 @@
+fixes:
+  - |
+    Resolve loop in local watchdog plugin
+ 
+    When the local watchdog (LWD) expires a task, the LWD plugin `20_sysinfo`
+    goes into an infinite loop since the directory `/mnt/testarea` is not
+    created for the non-rhts restraint package. An error returned by `diff`
+    utility within an infinite loop was not anticipated.  The fix
+    terminates the infinite loop when diff returns error.


### PR DESCRIPTION
…kage

When the local watchdog (LWD) expires a task, the LWD plugin 20_sysinfo
goes into a loop since the directory /mnt/testarea is not created
for the non-rhts restraint package and an error within the infinite loop
did not account for this error.  There are two changes introduced in this
changeset.  First, handle the error 'file/directory not found'. Second,
quit the loop after period of time.

Bug: 1813935