### PR TITLE
Fix error during tito srpm builds

### DIFF
--- a/rel-eng/lib/restrainttito.py
+++ b/rel-eng/lib/restrainttito.py
@@ -34,6 +34,9 @@ class RestraintBuilder(Builder):
             self.sources.append(os.path.join(self.rpmbuild_sourcedir, tarball))
         return super(RestraintBuilder, self).tgz()
 
+    def _copy_extra_sources(self):
+        pass
+
 
 class RestraintVersionTagger(VersionTagger):
 


### PR DESCRIPTION
Tito is getting smarter and trying to do new things.
In the last release, they introduce a technique to copy all sources from the given spec file. This is something that will break our workflow where 3rd party Makefile handles sources.
Signed-off-by: Martin Styk <mastyk@redhat.com>