### PR TITLE
fix: Restraint commands exit status

### DIFF
--- a/releasenotes/notes/fix-commands-exit-958e93a3c928ce80.yaml
+++ b/releasenotes/notes/fix-commands-exit-958e93a3c928ce80.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - |
+    Correct commands exit status when argument parsing fails due to
+    bad syntax. Commands always return non-zero in case of failure.
+    

--- a/src/client.c
+++ b/src/client.c
@@ -1900,21 +1900,21 @@ int main(int argc, char *argv[]) {
     // convert job.xml to index.html
     pretty_results(app_data->run_dir);
 
-
 cleanup:
-    g_strfreev(hostarr);
-    if (job != NULL) {
-        g_free(job);
+
+    g_strfreev (hostarr);
+    g_free (job);
+
+    gboolean success = app_data->error == NULL;
+
+    if (!success) {
+        g_printerr ("%s [%s, %d]\n",
+                    app_data->error->message,
+                    g_quark_to_string (app_data->error->domain),
+                    app_data->error->code);
     }
-    if (app_data->error) {
-        int retcode = app_data->error->code;
-        g_printerr("%s [%s, %d]\n", app_data->error->message,
-                g_quark_to_string(app_data->error->domain),
-                app_data->error->code);
-        restraint_free_app_data(app_data);
-        return retcode;
-    } else {
-        restraint_free_app_data(app_data);
-        return EXIT_SUCCESS;
-    }
+
+    restraint_free_app_data (app_data);
+
+    return success ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/src/cmd_abort_main.c
+++ b/src/cmd_abort_main.c
@@ -15,11 +15,11 @@
     along with Restraint.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <stdlib.h>
 #include <glib.h>
 #include "cmd_abort.h"
 
 int main(int argc, char *argv[]) {
-    gint ret = EXIT_SUCCESS;
     GError *error = NULL;
 
     AbortAppData *app_data = g_slice_new0 (AbortAppData);
@@ -38,12 +38,12 @@ cleanup:
     g_slice_free(AbortAppData, app_data);
 
     if (error) {
-        ret = error->code;
         g_printerr("%s [%s, %d]\n", error->message,
                 g_quark_to_string(error->domain), error->code);
         g_clear_error(&error);
+
+        return EXIT_FAILURE;
     }
 
-    return ret;
-
+    return EXIT_SUCCESS;
 }

--- a/src/cmd_log_main.c
+++ b/src/cmd_log_main.c
@@ -15,13 +15,13 @@
     along with Restraint.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <stdlib.h>
 #include <glib.h>
 #include "cmd_log.h"
 
 int main(int argc, char *argv[]) {
 
     GError *error = NULL;
-    int retcode = EXIT_SUCCESS;
 
     LogAppData *app_data = g_slice_new0 (LogAppData);
 
@@ -39,11 +39,12 @@ cleanup:
     g_slice_free(LogAppData, app_data);
 
     if (error) {
-        retcode = error->code;
         g_printerr("%s [%s, %d]\n", error->message,
                 g_quark_to_string(error->domain), error->code);
         g_clear_error(&error);
-    }
-    return retcode;
-}
 
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/cmd_watchdog_main.c
+++ b/src/cmd_watchdog_main.c
@@ -15,6 +15,7 @@
     along with Restraint.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <stdlib.h>
 #include <glib.h>
 #include "cmd_watchdog.h"
 #include "errors.h"
@@ -22,7 +23,6 @@
 int main(int argc, char *argv[]) {
 
     GError *error = NULL;
-    gint ret = EXIT_SUCCESS;
     WatchdogAppData *app_data = g_slice_new0 (WatchdogAppData);
 
     if (!parse_watchdog_arguments(app_data, argc, argv, &error)) {
@@ -39,11 +39,12 @@ cleanup:
     g_slice_free(WatchdogAppData, app_data);
 
     if (error) {
-        ret = error->code;
         g_printerr("%s [%s, %d]\n", error->message,
                 g_quark_to_string(error->domain), error->code);
         g_clear_error(&error);
-    }
-    return ret;
-}
 
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Exit status for Restraint commands was misleading due to use of `error->code` as value. As 0 is an actual error code, the command failed successfully.

Replace `error->code` with `EXIT_FAILURE` for exit status in,
- Restraint client
- rstrnt-abort
- rstrnt-adjust-watchdog
- rstrnt-report-log

Resolves #79 