### PR TITLE
Fix unsafe watchdog handling

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -339,8 +339,16 @@ server_recipe_callback (SoupServer *server, SoupMessage *client_msg,
         // Extract the number of watchdog seconds
         data_table = soup_form_decode(client_msg->request_body->data);
         seconds_string = g_hash_table_lookup(data_table, "seconds");
-        max_time = g_ascii_strtoull(seconds_string, NULL, BASE10);
-        seconds_string = NULL;
+
+        if (seconds_string != NULL) {
+            max_time = g_ascii_strtoull (seconds_string, NULL, BASE10);
+            seconds_string = NULL;
+        } else {
+            /* TODO: Most likely this case should be a bad request or
+             some value other than 0. EWD_TIME? */
+            max_time = 0;
+        }
+
         g_hash_table_destroy (data_table);
 
         // Update the number of watchdog seconds for External watchdog

--- a/src/server.c
+++ b/src/server.c
@@ -303,8 +303,7 @@ server_recipe_callback (SoupServer *server, SoupMessage *client_msg,
     SoupURI *server_uri;
     SoupMessageHeadersIter iter;
     const gchar *name, *value;
-    GHashTable *data_table, *new_table;
-    gchar *seconds_string;
+    GHashTable *new_table;
     guint64 max_time = 0;
     gchar *form_data;
     gchar *form_seconds;
@@ -334,10 +333,15 @@ server_recipe_callback (SoupServer *server, SoupMessage *client_msg,
         g_free (uri);
         server_msg = soup_message_new_from_uri ("PUT", server_uri);
     } else if (g_str_has_suffix (path, "watchdog")) {
+        GHashTable *data_table;
+        gchar      *seconds_string;
+
         // Extract the number of watchdog seconds
         data_table = soup_form_decode(client_msg->request_body->data);
         seconds_string = g_hash_table_lookup(data_table, "seconds");
         max_time = g_ascii_strtoull(seconds_string, NULL, BASE10);
+        seconds_string = NULL;
+        g_hash_table_destroy (data_table);
 
         // Update the number of watchdog seconds for External watchdog
         // by increasing it by EWD_TIME


### PR DESCRIPTION
- `data_table` was leaking the hash table from `soup_form_decode`
- A watchdog request without `seconds` in the form data crashed restraintd due to `g_ascii_strtoull` called with a NULL pointer.