### PR TITLE
Refactor rstrnt_listen_any_local

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -616,7 +616,7 @@ rstrnt_listen_any_local (SoupServer *server, guint port)
         uris = soup_server_get_uris (server);
         port = ((SoupURI *) uris->data)->port;
 
-        g_slist_free (uris);
+        g_slist_free_full (uris, (GDestroyNotify) soup_uri_free);
     }
 
     is_listening |= soup_server_listen_local (server, port, SOUP_SERVER_LISTEN_IPV6_ONLY, &error);


### PR DESCRIPTION
Instead of a boolean indicating if the server is listening or not, return the port where the server is listening, or 0 if it's not listening. With this change we can remove the code that was used to get the port after the call.

The list returned by `soup_server_get_uris` and the URIs in it should be freed by the caller. Use `g_slist_free_full` with `g_soup_uri_free` instead of `g_slist_free`.


