### PR TITLE
Refactor host parsing in Restraint client

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -1722,7 +1722,7 @@ parse_host (const gchar *connect_uri)
 }
 
 static gboolean add_recipe_host(const gchar *value, AppData *app_data,
-                                guint *recipe_id) {
+                                guint recipe_id) {
     gchar **args;
     gchar *connect_uri = NULL;
     gchar *id = NULL;
@@ -1731,7 +1731,7 @@ static gboolean add_recipe_host(const gchar *value, AppData *app_data,
 
     args = g_strsplit(value, "=", 2);
     if (g_strv_length(args) != 2) {
-        id = g_strdup_printf("%u", (*recipe_id)++);
+        id = g_strdup_printf("%u", recipe_id);
         connect_uri = args[0];
     } else {
         id = args[0];
@@ -1831,7 +1831,7 @@ int main(int argc, char *argv[]) {
     guint recipe_id = 1;
     if (hostarr != NULL) {
         for (int i = 0; i < g_strv_length(hostarr); i++) {
-            if (!add_recipe_host(hostarr[i], app_data, &recipe_id)) {
+            if (!add_recipe_host(hostarr[i], app_data, recipe_id++)) {
                 if (app_data->error == NULL) {
                     g_set_error(&app_data->error, RESTRAINT_ERROR,
                                 RESTRAINT_CMDLINE_ERROR,

--- a/src/client.c
+++ b/src/client.c
@@ -1721,17 +1721,24 @@ parse_host (const gchar *connect_uri)
     return ssh_destination;
 }
 
-static gboolean add_recipe_host(const gchar *value, AppData *app_data,
-                                guint recipe_id) {
-    gchar **args;
-    gchar *connect_uri = NULL;
-    gchar *id = NULL;
-    gboolean result = TRUE;
-    gchar **ssh_destination;
+static gboolean
+add_recipe_host (const gchar *value,
+                 AppData     *app_data,
+                 guint        recipe_id)
+{
+    gboolean   parse_result;
+    gchar     *connect_uri;
+    gchar     *id;
+    gchar    **args;
+    gchar    **ssh_destination;
 
-    args = g_strsplit(value, "=", 2);
-    if (g_strv_length(args) != 2) {
-        id = g_strdup_printf("%u", recipe_id);
+    g_return_val_if_fail (value != NULL && strlen (value) > 0, FALSE);
+    g_return_val_if_fail (app_data != NULL, FALSE);
+
+    args = g_strsplit (value, "=", 2);
+
+    if (g_strv_length (args) == 1) {
+        id = g_strdup_printf ("%u", recipe_id);
         connect_uri = args[0];
     } else {
         id = args[0];
@@ -1739,8 +1746,9 @@ static gboolean add_recipe_host(const gchar *value, AppData *app_data,
     }
 
     ssh_destination = parse_host (connect_uri);
+    parse_result = ssh_destination != NULL;
 
-    if (ssh_destination != NULL) {
+    if (parse_result) {
         RecipeData *recipe_data;
 
         recipe_data = new_recipe_data (app_data, id);
@@ -1749,17 +1757,13 @@ static gboolean add_recipe_host(const gchar *value, AppData *app_data,
 
         g_free (ssh_destination[0]);
         g_free (ssh_destination);
-
-        result = TRUE;
-    } else {
-        result = FALSE;
     }
 
     g_free (id);
     g_free (connect_uri);
     g_free (args);
 
-    return result;
+    return parse_result;
 }
 
 static void recipe_init(gchar *id, RecipeData *recipe_data,

--- a/src/client.c
+++ b/src/client.c
@@ -1690,7 +1690,7 @@ parse_host (const gchar *connect_uri)
     /* [user@]hostname[:port][/ssh_port] */
     regex = g_regex_new ("^(([\\w\\.\\-]+)@)?([\\w\\.\\-]+)((:\\d+)?(/\\d+)?)?$", 0, 0, NULL);
 
-    if (g_regex_match(regex, connect_uri, 0, &match_info)) {
+    if (g_regex_match (regex, connect_uri, 0, &match_info)) {
         gchar *deprecated;
 
         ssh_destination = g_malloc (sizeof (gchar *) * 3);
@@ -1712,11 +1712,12 @@ parse_host (const gchar *connect_uri)
 
         g_free (deprecated);
     } else {
-        g_printerr("Malformed host: %s, see help for reference\n", connect_uri);
+        g_printerr ("Malformed host: %s, see help for reference\n", connect_uri);
         ssh_destination = NULL;
     }
-    g_match_info_free(match_info);
-    g_regex_unref(regex);
+
+    g_match_info_free (match_info);
+    g_regex_unref (regex);
 
     return ssh_destination;
 }

--- a/src/client.c
+++ b/src/client.c
@@ -1786,6 +1786,7 @@ int main(int argc, char *argv[]) {
     app_data->rsh_cmd = "ssh";
     app_data->restraint_path = "restraintd";
     app_data->restraint_port = 0;
+    app_data->max_retries = CONN_RETRIES;
 
     init_result_hash (app_data);
     app_data->recipes = g_hash_table_new_full(g_str_hash, g_str_equal,
@@ -1828,10 +1829,6 @@ int main(int argc, char *argv[]) {
     gboolean parse_succeeded = g_option_context_parse(context, &argc, &argv,
             &app_data->error);
     g_option_context_free(context);
-
-    if (app_data->max_retries == 0) {
-        app_data->max_retries = CONN_RETRIES;
-    }
 
     /* -t, --host option parsing */
     if (hostarr != NULL) {

--- a/src/client.c
+++ b/src/client.c
@@ -1833,17 +1833,21 @@ int main(int argc, char *argv[]) {
         app_data->max_retries = CONN_RETRIES;
     }
 
-    guint recipe_id = 1;
+    /* -t, --host option parsing */
     if (hostarr != NULL) {
-        for (int i = 0; i < g_strv_length(hostarr); i++) {
-            if (!add_recipe_host(hostarr[i], app_data, recipe_id++)) {
-                if (app_data->error == NULL) {
-                    g_set_error(&app_data->error, RESTRAINT_ERROR,
-                                RESTRAINT_CMDLINE_ERROR,
-                                "Failed to add recipe host.");
-                }
-                goto cleanup;
-            }
+        guint recipe_id = 1;
+
+        for (gchar **host = hostarr; *host != NULL; host++) {
+            if (add_recipe_host (*host, app_data, recipe_id++))
+                continue;
+
+            if (app_data->error == NULL)
+                g_set_error (&app_data->error,
+                             RESTRAINT_ERROR,
+                             RESTRAINT_CMDLINE_ERROR,
+                             "Failed to add recipe host.");
+
+            goto cleanup;
         }
     }
 


### PR DESCRIPTION
These changes were left out from #69 to speed up the reviews.

- Fix style in `parse_host` and `add_recipe_host`
- Check argument values in `add_recipe_host` and unify parse check and return value
- Increment `recipe_id` in the loop, instead of `add_recipe_host`
- Reduce indentation in loop for host parsing and use the NULL-terminated array for iteration
- Set default for connection retries option before parsing

