### PR TITLE
Fix leaks in Restraint client

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -120,7 +120,7 @@ json_to_hashtable (struct json_object *jobj) {
     GHashTable *form_data_set;
     int val_type;
     form_data_set = g_hash_table_new_full(g_str_hash, g_str_equal,
-                                          g_free, NULL);
+                                          NULL, NULL);
     json_object_object_foreach(jobj, key, val) {
         val_type = json_object_get_type(val);
         switch (val_type) {

--- a/src/client.c
+++ b/src/client.c
@@ -782,8 +782,11 @@ handle_message (const char *message,
                   headers,
                   json_body,
                   user_data);
-    } else
+    } else {
         g_message ("no registered callback matches %s", rstrnt_path);
+    }
+
+    json_object_put (jobj);
     g_hash_table_destroy(headers);
 }
 

--- a/src/client.c
+++ b/src/client.c
@@ -45,10 +45,17 @@ static gboolean run_recipe_handler (gpointer user_data);
 
 static void restraint_free_recipe_data(RecipeData *recipe_data)
 {
+    g_return_if_fail (recipe_data != NULL);
+
     if (recipe_data->tasks != NULL) {
         g_hash_table_destroy(recipe_data->tasks);
     }
+
     g_string_free(recipe_data->body, TRUE);
+    g_clear_object (&recipe_data->cancellable);
+    g_free (recipe_data->rhost);
+    g_free (recipe_data->connect_uri);
+
     g_slice_free(RecipeData, recipe_data);
 }
 


### PR DESCRIPTION
Members of `recipe_data` were not freed in `restraint_free_recipe_data`,
+ cancellable is allocated in `new_recipe_data` but never freed
+ `rhost` and `connect_uri` are allocated during host parsing, but never freed

In `handle_message`, the json object returned by `json_tokener_parse` was never freed, and correcting it revealed that the destroy key function used in the hash table returned by `json_to_hashtable` was freeing the json object's own allocated key, leaving the object in a bad state.