### PR TITLE
Add tox support for docs creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ rel-eng/lib/__pycache__/
 /docs/_build
 tags
 cscope.out
+.tox/

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py37
+skipsdist=True
+
+[testenv:docs]
+description = invoke sphinx-build to build the HTML docs
+basepython = python3.7
+deps = sphinx >= 1.7.5, < 2
+commands = sphinx-build docs "docs/_build/html" --color -bhtml {posargs}


### PR DESCRIPTION
```
mastyk@mcas: /home/mastyk/work/github.com/StykMartin/restraint git:(one-tox-please) ✗ 
➜   tox -e docs                          
docs installed: alabaster==0.7.12,Babel==2.8.0,certifi==2020.4.5.1,chardet==3.0.4,docutils==0.16,idna==2.9,imagesize==1.2.0,Jinja2==2.11.2,MarkupSafe==1.1.1,packaging==20.4,Pygments==2.6.1,pyparsing==2.4.7,pytz==2020.1,requests==2.23.0,six==1.15.0,snowballstemmer==2.0.0,Sphinx==1.8.5,sphinxcontrib-websupport==1.2.2,urllib3==1.25.9
docs run-test-pre: PYTHONHASHSEED='1619422057'
docs run-test: commands[0] | sphinx-build docs docs/_build/html --color -bhtml
Running Sphinx v1.8.5
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 0 source files that are out of date
updating environment: 0 added, 0 changed, 0 removed
looking for now-outdated files... none found
no targets are out of date.
build succeeded.

The HTML pages are in docs/_build/html.
____________________________________________
```

Small tox support to get docs running out of the box.
Signed-off-by: Martin Styk <mastyk@redhat.com>