### PR TITLE
stderr: print recipe_id when task hits LWD

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -954,7 +954,7 @@ task_handler (gpointer user_data)
               task->state = TASK_COMPLETE;
           } else if (task->localwatchdog) {
               // If the task is not finished but localwatchdog expired.
-              g_string_printf(message, "** Localwatchdog task: %s [%s]\n", task->task_id, task->path);
+              g_string_printf(message, "** Localwatchdog task: %s [%s] [R:%s]\n", task->task_id, task->path, task->recipe->recipe_id);
               task->state = TASK_COMPLETE;
           } else if (task->started) {
               // If the task is not finished but started then skip fetching the task again.


### PR DESCRIPTION
When there is a localwatchdog hit, restraint client prints info to
stderr. However, this contains only task_id and task_path.
It is useful to know in what recipe_id this happened to process the
results.

Output changes from

** Message: 15:51:50.108: ** Localwatchdog task: 1 [/mnt/tests/gitlab.com/../spin]

to

** Message: 15:51:50.108: ** Localwatchdog task: 1 [/mnt/tests/gitlab.com/../spin] [1234]

Signed-off-by: Jakub Racek <jracek@redhat.com>