### PR TITLE
Fix: Stop logging `LWD is disabled` every minute

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -604,6 +604,15 @@ Where:
    restraint repo is pulled and ``restraintd`` image is built.  By default, the
    installed image is executed.
 
+
+.. option:: --timeout <minutes>
+
+   This optional argument ``--timeout`` specifies the time in minutes for
+   ssh to timeout.  This option takes affect when the `rsh` argument is not
+   used. The default timeout is 5 minutes.  A keepalive message is sent every
+   minute to the server and this is done for the number of minutes provided.
+   If there is no response, the ssh client will disconnect.
+
 .. option:: -v
 
    You can pass ``-v`` for more verbose output which will show every task

--- a/releasenotes/notes/no-chatty-LWD-log-3d0da15e99a968f4.yaml
+++ b/releasenotes/notes/no-chatty-LWD-log-3d0da15e99a968f4.yaml
@@ -1,0 +1,14 @@
+fixes:
+  - |
+    Stop logging `LWD is disabled` every minute
+
+    When LWD (Local Watchdog) is disabled, there is a message in the
+    harness log that reports this every minute.  The message looks
+    like: `Localwatchdog at:  Disabled! `.  This changeset makes sure
+    it is no longer reported repeatedly when `no_localwatchdog=true`
+    is configured in the task `metadata` file.  To ensure there is some
+    type of keepalive mechanism, the client now performs ssh keepalive
+    towards the server.  This timeout value is configurable by use
+    of the restraint client option `--timeout` which only affects default
+    behavior. The timeout value has no effect when the `rsh` argument
+    is used.

--- a/src/task.h
+++ b/src/task.h
@@ -130,7 +130,6 @@ typedef struct {
     TaskSetupState fail_state;
     gchar expire_time[80];
     const gchar *logpath;
-    gboolean skip_remaining;
 } TaskRunData;
 
 Task *restraint_task_new(void);


### PR DESCRIPTION
When LWD (Local Watchdog) is disabled, there is a message in the
harness log that reports this every minute.  The message looks
like: `Localwatchdog at:  Disabled! `.  This changeset makes sure
it is no longer reported repeatedly when `no_localwatchdog=true`
is configured in the task `metadata` file.
To make sure the connection between client and server don't timeout,
the ssh arguments `ServerAliveInterval` and `ServerAliveCountMax` are
set on the `restraint` client. The `ServerAliveInterval` is set to
60 seconds while `ServerAliveCountMax` is set fo 5.  This results in
an idle timeout of 5 minutes.  The `ServerAliveCountMax` can be
altered by the user using `--timeout` argument.
Replaced localtime() with localtime_r() to resolve error reported
by the LGTM checker.

Bug: 1598329