### PR TITLE
Fix noisy output in restraint client

### DIFF
--- a/releasenotes/notes/fix-noisy-client-output-7131109005ba0a1c.yaml
+++ b/releasenotes/notes/fix-noisy-client-output-7131109005ba0a1c.yaml
@@ -1,0 +1,7 @@
+fixes:
+  - |
+    Fix noisy Restraint client output
+    The Restraint client was not honoring the verbosity levels and it
+    was printing all output available even when the verbosity level was
+    the lowest.
+    The Restraint client output now behaves similarly to release 0.1.45.

--- a/src/client.c
+++ b/src/client.c
@@ -768,10 +768,14 @@ handle_message (const char *message,
 
     jobj = json_tokener_parse(message);
     json_headers = find_object(jobj, "headers");
-    if (!json_headers) {
-        g_message("%s", message);
+
+    if (json_headers == NULL) {
+        gchar *trunc_host = g_strndup (recipe_data->rhost, 20);
+        g_print ("[%-20s] %s", trunc_host, message);
+        g_free (trunc_host);
         return;
     }
+
     json_body = find_object(jobj, "body");
     headers = json_to_hashtable(json_headers);
     rstrnt_path = g_hash_table_lookup (headers, "rstrnt-path");

--- a/src/process.c
+++ b/src/process.c
@@ -304,6 +304,11 @@ process_run (const gchar *command,
         if (envp)
             environ = (gchar **) envp;
 
+        // Print the command being executed.
+        gchar *pcommand = g_strjoinv (" ", (gchar **) process_data->command);
+        g_print ("use_pty:%s %s\n", use_pty ? "TRUE" : "FALSE", pcommand);
+        g_free (pcommand);
+
         /* Spawn the command */
         if (execvp (*process_data->command, (gchar **) process_data->command) == -1) {
             g_warning ("Failed to exec() %s, %s error:%s\n",
@@ -315,11 +320,6 @@ process_run (const gchar *command,
     }
 
     /* Parent process. */
-
-    // Print the command being executed.
-    gchar *pcommand = g_strjoinv (" ", (gchar **) process_data->command);
-    g_message ("use_pty:%s %s\n", use_pty ? "TRUE" : "FALSE", pcommand);
-    g_free (pcommand);
 
     // If we get the cancel signal kill any running process
     if (process_data->cancellable) {

--- a/src/process.h
+++ b/src/process.h
@@ -19,6 +19,9 @@
 
 #define HEARTBEAT 1 * 60 // heartbeat every 1 minute
 
+/* Used for process IO callbacks */
+#define IO_BUFFER_SIZE 8192
+
 typedef void (*ProcessTimeoutCallback) (gpointer user_data,
                                         guint64 *time_remain);
 

--- a/src/recipe.c
+++ b/src/recipe.c
@@ -619,10 +619,8 @@ recipe_handler (gpointer user_data)
     }
 
     // write message out to stderr
-    if (message->len) {
-      if (fwrite(message->str, sizeof(gchar), message->len, stderr) != message->len)
-          g_warning ("failed to write message");
-    }
+    if (message->len > 0)
+        g_printerr ("%s", message->str);
 
     g_string_free(message, TRUE);
     return result;

--- a/src/server.c
+++ b/src/server.c
@@ -677,10 +677,7 @@ int main(int argc, char *argv[]) {
     exit (PARSE_ARGS_FAILED);
   }
 
-  if (app_data->stdin) {
-      g_set_printerr_handler (null_print);
-      g_log_set_writer_func (null_log_writer, NULL, NULL);
-  } else {
+  if (!app_data->stdin) {
       app_data->config_file = g_build_filename (VAR_LIB_PATH, config, NULL);
       app_data->recipe_url = restraint_config_get_string (app_data->config_file,
                                                           "restraint",
@@ -739,6 +736,8 @@ int main(int argc, char *argv[]) {
   // Read job.xml from STDIN
   if (app_data->stdin) {
       read_job_xml(app_data, soup_server);
+      g_set_printerr_handler (null_print);
+      g_log_set_writer_func (null_log_writer, NULL, NULL);
   }
 
   /* enter mainloop */

--- a/src/server.c
+++ b/src/server.c
@@ -592,6 +592,12 @@ null_log_writer (GLogLevelFlags   log_level,
   return G_LOG_WRITER_HANDLED;
 }
 
+static void
+null_print (const gchar *string)
+{
+    return;
+}
+
 /* Bind server to available IPv4 and IPv6 local addresses
  *
  * The server must NOT already be listening on any interface.
@@ -672,7 +678,7 @@ int main(int argc, char *argv[]) {
   }
 
   if (app_data->stdin) {
-      g_set_printerr_handler (NULL);
+      g_set_printerr_handler (null_print);
       g_log_set_writer_func (null_log_writer, NULL, NULL);
   } else {
       app_data->config_file = g_build_filename (VAR_LIB_PATH, config, NULL);

--- a/src/server.c
+++ b/src/server.c
@@ -152,12 +152,11 @@ server_io_callback (GIOChannel *io, GIOCondition condition, gpointer user_data) 
     AppData *app_data = (AppData *) client_data->user_data;
     GError *tmp_error = NULL;
 
-    gchar buf[10000];
-    gsize bytes_read;
+    gchar buf[IO_BUFFER_SIZE] = { 0 };
+    gsize bytes_read = 0;
 
     if (condition & G_IO_IN) {
-        //switch (g_io_channel_read_line_string(io, s, NULL, &tmp_error)) {
-        switch (g_io_channel_read_chars(io, buf, 10000, &bytes_read, &tmp_error)) {
+        switch (g_io_channel_read_chars (io, buf, IO_BUFFER_SIZE, &bytes_read, &tmp_error)) {
           case G_IO_STATUS_NORMAL:
             if (fwrite (buf, sizeof(gchar), bytes_read, stdout) != bytes_read)
               g_warning ("failed to write message");

--- a/src/task.c
+++ b/src/task.c
@@ -444,7 +444,7 @@ task_handler_callback (gint pid_result, gboolean localwatchdog, gpointer user_da
 
     task->version = get_package_version(task->fetch.package_name, &tmp_error);
     if (tmp_error) {  // Error: However, report and continue on
-        g_print("FAILED Get RPM version: %s", tmp_error->message);
+        g_warning ("FAILED Get RPM version: %s", tmp_error->message);
         g_clear_error(&tmp_error);
     }
     if (error) {

--- a/src/task.c
+++ b/src/task.c
@@ -210,13 +210,14 @@ io_callback (GIOChannel *io, GIOCondition condition, const gchar *logpath, gpoin
     gsize bytes_read = 0;
 
     if (condition & G_IO_IN) {
-        switch (g_io_channel_read_chars (io, buf, IO_BUFFER_SIZE, &bytes_read, &tmp_error)) {
+        switch (g_io_channel_read_chars (io, buf, IO_BUFFER_SIZE - 1, &bytes_read, &tmp_error)) {
           case G_IO_STATUS_NORMAL:
+
+            /* Suppress task output in restraintd stdout/stderr unless
+               G_MESSAGES_DEBUG is used. */
+            g_debug ("%s", buf);
+
             /* Push data to our connections.. */
-
-            if (fwrite (buf, sizeof (gchar), bytes_read, stdout) != bytes_read)
-                g_warning ("failed to write message");
-
             connections_write(app_data, logpath, buf, bytes_read);
             return G_SOURCE_CONTINUE;
 

--- a/src/task.c
+++ b/src/task.c
@@ -206,12 +206,11 @@ io_callback (GIOChannel *io, GIOCondition condition, const gchar *logpath, gpoin
     AppData *app_data = (AppData *) user_data;
     GError *tmp_error = NULL;
 
-    gchar buf[10000];
-    gsize bytes_read;
+    gchar buf[IO_BUFFER_SIZE] = { 0 };
+    gsize bytes_read = 0;
 
     if (condition & G_IO_IN) {
-        //switch (g_io_channel_read_line_string(io, s, NULL, &tmp_error)) {
-        switch (g_io_channel_read_chars(io, buf, 10000, &bytes_read, &tmp_error)) {
+        switch (g_io_channel_read_chars (io, buf, IO_BUFFER_SIZE, &bytes_read, &tmp_error)) {
           case G_IO_STATUS_NORMAL:
             /* Push data to our connections.. */
 

--- a/src/task.c
+++ b/src/task.c
@@ -1112,9 +1112,8 @@ task_handler (gpointer user_data)
       result = G_SOURCE_CONTINUE;
       break;
   }
-  if (message->len) {
-    if (fwrite(message->str, sizeof(gchar), message->len, stderr) != message->len)
-        g_warning ("failed to write message");
+  if (message->len > 0) {
+    g_printerr ("%s", message->str);
     connections_write(app_data, LOG_PATH_HARNESS, message->str, message->len);
   }
   g_string_free(message, TRUE);

--- a/src/test_dependency.c
+++ b/src/test_dependency.c
@@ -90,7 +90,12 @@ static void test_soft_dependencies_success (void)
     softdependencies = g_slist_prepend (dependencies, "PackageA");
     softdependencies = g_slist_prepend (softdependencies, "Packagefail");
     softdependencies = g_slist_prepend (softdependencies, "PackageC");
-    gchar *expected = "dummy yum: installing PackageC\ndummy yum: fail\ndummy yum: installing PackageA\n";
+    gchar *expected = "use_pty:FALSE rstrnt-package install PackageC\n"
+                      "dummy yum: installing PackageC\n"
+                      "use_pty:FALSE rstrnt-package install Packagefail\n"
+                      "dummy yum: fail\n"
+                      "use_pty:FALSE rstrnt-package install PackageA\n"
+                      "dummy yum: installing PackageA\n";
 
     run_data = g_slice_new0 (RunData);
     run_data->loop = g_main_loop_new (NULL, TRUE);
@@ -141,7 +146,8 @@ static void test_dependencies_success (void)
     dependencies = g_slist_prepend (dependencies, "PackageA");
     dependencies = g_slist_prepend (dependencies, "PackageB");
     dependencies = g_slist_prepend (dependencies, "PackageC");
-    gchar *expected = "dummy yum: installing PackageC PackageB PackageA\n";
+    gchar *expected = "use_pty:FALSE rstrnt-package install PackageC PackageB PackageA\n"
+                      "dummy yum: installing PackageC PackageB PackageA\n";
 
     run_data = g_slice_new0 (RunData);
     run_data->loop = g_main_loop_new (NULL, TRUE);
@@ -192,7 +198,8 @@ static void test_dependencies_fail (void)
     dependencies = g_slist_prepend (dependencies, "PackageA");
     dependencies = g_slist_prepend (dependencies, "Packagefail");
     dependencies = g_slist_prepend (dependencies, "PackageC");
-    gchar *expected = "dummy yum: fail\n";
+    gchar *expected = "use_pty:FALSE rstrnt-package install PackageC Packagefail PackageA\n"
+                      "dummy yum: fail\n";
 
     run_data = g_slice_new0 (RunData);
     run_data->loop = g_main_loop_new (NULL, TRUE);
@@ -243,7 +250,14 @@ static void test_dependencies_ignore_fail (void)
     dependencies = g_slist_prepend (dependencies, "PackageA");
     dependencies = g_slist_prepend (dependencies, "Packagefail");
     dependencies = g_slist_prepend (dependencies, "PackageC");
-    gchar *expected = "dummy yum: fail\ndummy yum: installing PackageC\ndummy yum: fail\ndummy yum: installing PackageA\n";
+    gchar *expected = "use_pty:FALSE rstrnt-package install PackageC Packagefail PackageA\n"
+                      "dummy yum: fail\n"
+                      "use_pty:FALSE rstrnt-package install PackageC\n"
+                      "dummy yum: installing PackageC\n"
+                      "use_pty:FALSE rstrnt-package install Packagefail\n"
+                      "dummy yum: fail\n"
+                      "use_pty:FALSE rstrnt-package install PackageA\n"
+                      "dummy yum: installing PackageA\n";
 
     run_data = g_slice_new0 (RunData);
     run_data->loop = g_main_loop_new (NULL, TRUE);

--- a/src/test_process.c
+++ b/src/test_process.c
@@ -220,7 +220,7 @@ static void test_no_hang(void) {
     // Watchdog fail to command time > max time
     const guint64 maximumtime = 60;
     const gchar *command = "hang_test";
-    gchar *expected = "foo\nbar\n";
+    gchar *expected = "use_pty:FALSE hang_test\nfoo\nbar\n";
     GString *output = g_string_new(NULL);
     gchar **outsplit = NULL;
 
@@ -274,7 +274,7 @@ static void test_use_pty(void) {
     // Watchdog fail to command time > max time
     const guint64 maximumtime = 60;
     const gchar *command = "is_tty";
-    gchar *expected = "True\r\n";
+    gchar *expected = "use_pty:TRUE is_tty\r\nTrue\r\n";
 
     run_data = g_slice_new0 (RunData);
     run_data->loop = g_main_loop_new (NULL, TRUE);
@@ -311,7 +311,7 @@ static void test_dont_use_pty(void) {
     RunData *run_data;
     const guint64 maximumtime = 60;
     const gchar *command = "is_tty";
-    gchar *expected = "False\n";
+    gchar *expected = "use_pty:FALSE is_tty\nFalse\n";
 
     run_data = g_slice_new0 (RunData);
     run_data->loop = g_main_loop_new (NULL, TRUE);
@@ -354,7 +354,7 @@ test_process_read_empty_stdin (void)
 
     maximumtime = 3;
     command = "cat";
-    expected = "";
+    expected ="use_pty:FALSE cat\n";
 
     run_data = g_slice_new0 (RunData);
     run_data->loop = g_main_loop_new (NULL, TRUE);
@@ -391,12 +391,14 @@ test_process_read_content_input (void)
 {
     RunData *run_data;
     gchar   *command;
+    gchar   *content_input;
     gchar   *expected;
     guint64  maximumtime;
 
     maximumtime = 3;
     command = "cat";
-    expected = "Some text for stdin\n";
+    content_input = "Some text for stdin\n";
+    expected = "use_pty:FALSE cat\nSome text for stdin\n";
 
     run_data = g_slice_new0 (RunData);
     run_data->loop = g_main_loop_new (NULL, TRUE);
@@ -410,7 +412,7 @@ test_process_read_content_input (void)
                  NULL,
                  test_process_io_cb,
                  test_process_finish_cb,
-                 expected,
+                 content_input,
                  strlen (expected),
                  FALSE,
                  NULL,
@@ -438,7 +440,7 @@ test_process_read_empty_stdin_pty (void)
 
     maximumtime = 3;
     command = "cat";
-    expected = "";
+    expected = "use_pty:TRUE cat\r\n";
 
     run_data = g_slice_new0 (RunData);
     run_data->loop = g_main_loop_new (NULL, TRUE);


### PR DESCRIPTION
After the removal of libssh, communication between Restraint client and `restraintd` is done through stdout/stderr. In a nutshell, the stdout/stderr from `restraintd` is printed in the client. When `restraintd` is ran by the client, messages sent with `connections_write` are written to `restraintd` stdout too, so these shouldn't be printed outside `connections_write`, otherwise they will be duplicated without proper formatting to match them with the test host. In most cases this was controlled by printing these messages to stderr and suppressing stderr output with a null printer/writer.

- Fix client output format. Print to stdout and include the hostname where the recipe is running
- Add null print handler to suppress `g_printerr` output in `restraintd` when it runs through the client
- Use `g_printerr` for harness logging, which will be suppressed when `restraintd` is ran by the client
- Suppress logging just before main loop starts to avoid hiding start messages 
- Print the process command in the child, to revert to release 0.1.45 behaviour
- Adjust IO callbacks to not output to stdout when `restraintd` is ran by the client and ensure that the buffers are always NULL terminated
- While setting task version, print error from get_package_version to STDERR with g_warning, instead of STDOUT

Resolves #87 
