### PR TITLE
restraint systemd: Have pre-check script wait for IP address

### DIFF
--- a/init.d/restraintd.service
+++ b/init.d/restraintd.service
@@ -10,6 +10,7 @@ ExecStartPre=/usr/bin/check_beaker
 ExecStart=/usr/bin/restraintd --port 8081
 KillMode=process
 OOMScoreAdjust=-1000
+TimeoutStartSec=180
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/check_beaker
+++ b/scripts/check_beaker
@@ -27,3 +27,31 @@ recipe_url=$BEAKER_LAB_CONTROLLER_URL/recipes/$BEAKER_RECIPE_ID/
 EOF
 fi
 fi
+
+# Try for up to 60 seconds to make sure system has an IP address
+if command -v hostname; then
+    COUNT=0
+    # 12 tries * 5 seconds = Maximum 60 seconds
+    MAX_TRIES=12
+    # Set to -1, so that if already have an IP address we won't print message
+    IP_FAIL="-1"
+    # Loop until we have an IP address.
+    # 'hostname -I' will output something like: 192.168.1.1 if we have an
+    # IP address. If no IP address it will output a blank line.
+    while ! hostname -I | grep '[0-9]'
+    do
+        IP_FAIL=0
+        COUNT=$(( COUNT + 1 ))
+        echo "$0: Waiting for IP address. Attempt: ${COUNT} of ${MAX_TRIES} failed" >&2
+        if [[ ${COUNT} -ge ${MAX_TRIES} ]]; then
+            IP_FAIL=1
+            break
+        fi
+        sleep 5.0
+    done
+    if [[ ${IP_FAIL} -eq 0 ]]; then
+        echo "$0: IP address acquired" >&2
+    elif [[ ${IP_FAIL} -eq 1 ]]; then
+        echo "$0: Failed to acquire IP address" >&2
+    fi
+fi


### PR DESCRIPTION
Add a check to make sure the system has an IP address to the pre-check
script (/usr/bin/check_beaker) that is run by systemd.

This check will try for a maximum of 60 seconds to see if the system
has acquired an IP address. If the system has an IP address it will
continue. If after 60 seconds it still doesn't have an IP address it
will continue.

Also increase start timeout to 3 minutes (180 seconds). The default
appears to be 90 seconds.

There was an issue found where Debian 10.3 boots up but takes a longer
than expected time to get an IP address from DHCP. This caused
restraint to time out and fail to fetch the recipe file.

Fixes: #101