### PR TITLE
fix: update copy_extra_sources method to match tito signature

### DIFF
--- a/rel-eng/lib/restrainttito.py
+++ b/rel-eng/lib/restrainttito.py
@@ -34,7 +34,8 @@ class RestraintBuilder(Builder):
             self.sources.append(os.path.join(self.rpmbuild_sourcedir, tarball))
         return super(RestraintBuilder, self).tgz()
 
-    def _copy_extra_sources(self):
+    # All sources are copied in our tgz method. Therefore, this method shouldn't copy anything anymore.
+    def copy_extra_sources(self):
         pass
 
 


### PR DESCRIPTION
Tito made change in method during 0.6.14 release.
Method is no longer private therefore we have to update method signature in same way.

Change in tito: 
https://github.com/rpm-software-management/tito/commit/c3c1de77ccb8a85ea79ae1eae51043105eb8fb57

Signed-off-by: Martin Styk <mastyk@redhat.com>