### PR TITLE
Decouple LWD from restraint-rhts

### DIFF
--- a/plugins/localwatchdog.d/20_sysinfo
+++ b/plugins/localwatchdog.d/20_sysinfo
@@ -8,7 +8,7 @@ PS_LWD=$(mktemp -d)
 # Check to see if journalctl exists.
 if command -v journalctl 2> /dev/null; then
     JOURNALCTL=true
-    LOGFILE=/mnt/testarea/journalctl
+    LOGFILE=$(mktemp -t journalctl.XXXXX)
 else
     JOURNALCTL=false
     LOGFILE=/var/log/messages
@@ -18,7 +18,7 @@ function WatchFile ()
 {
     FILE=$1
 
-    TMPFILE=$(mktemp -p /mnt/testarea -t Watch.XXXXX)
+    TMPFILE=$(mktemp -t Watch.XXXXX)
     while true; do
         if [ $JOURNALCTL = true ]; then
             journalctl -b > $FILE
@@ -76,7 +76,7 @@ echo "Dumping slabinfo - Stop - $timestamp" >> $SLABLOG
 logger -p local2.info -t "SlabCacheInfo" -f $SLABLOG
 
 if [ $JOURNALCTL = true ]; then
-    journalctl -b > /mnt/testarea/journalctl
+    journalctl -b > "$LOGFILE"
 fi
 
 # Submit dmesg log if any output

--- a/src/releasenotes/notes/decouple-lwd-from-rhts-7c94606e386abe79.yaml
+++ b/src/releasenotes/notes/decouple-lwd-from-rhts-7c94606e386abe79.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Remove restraint-rhts dependency from local watchdog plugins
+    The sysinfo plugin depended on a path provided by restraint-rhts,
+    and failed when the package was not installed.


### PR DESCRIPTION
The sysinfo LWD plugin was using /mnt/tests directory for storing temporary files, and this directory is provided my restraint-rhts, therefore the plugin failed when the restraint-rhts package was not installed.

Use default mktemp location for temporary files.

Closes #105 