### PR TITLE
FIX: Add /var/lib/restraint/subdirs for non-RHTS

### DIFF
--- a/docs/remove_rhts.rst
+++ b/docs/remove_rhts.rst
@@ -8,7 +8,8 @@ This requires the exclusion of the legacy RHTS package or `restraint-rhts`
 package installation.  Below lists areas to draw attention in order
 to eliminate RHTS references.
 
-#. Use the `restraint` harness package and not `restraint-rhts` in your jobs.
+#. Install the `restraint` harness package and not `restraint-rhts` in
+   your jobs.
 #. Avoid defining tasks or dependencies which cause installation of the `RHTS` library.
 #. Replace `RHTS` scripts with `Restraint` scripts.  :ref:`legacy_rhts_cmds` provides
    a table which maps legacy to restraint scripts.

--- a/legacy/Makefile
+++ b/legacy/Makefile
@@ -10,6 +10,7 @@ clean:
 .PHONY: install
 install:
 	set -e; for i in $(SUBDIRS); do $(MAKE) -C $$i install; done
+	install -m 644 data/install_config $(DESTDIR)/var/lib/restraint
 
 .PHONY: check
 check:

--- a/legacy/Makefile
+++ b/legacy/Makefile
@@ -10,7 +10,7 @@ clean:
 .PHONY: install
 install:
 	set -e; for i in $(SUBDIRS); do $(MAKE) -C $$i install; done
-	install -m 644 data/install_config $(DESTDIR)/var/lib/restraint
+	install -m 644 data/install_config $(DESTDIR)/var/lib/restraint/
 
 .PHONY: check
 check:

--- a/legacy/data/install_config
+++ b/legacy/data/install_config
@@ -1,0 +1,2 @@
+[General]
+INSTALL_DIR=/mnt/tests

--- a/plugins/localwatchdog.d/20_sysinfo
+++ b/plugins/localwatchdog.d/20_sysinfo
@@ -8,7 +8,7 @@ PS_LWD=$(mktemp -d)
 # Check to see if journalctl exists.
 if command -v journalctl 2> /dev/null; then
     JOURNALCTL=true
-    LOGFILE=/mnt/testarea/journalctl
+    LOGFILE=/var/tmp/journalctl
 else
     JOURNALCTL=false
     LOGFILE=/var/log/messages
@@ -18,7 +18,7 @@ function WatchFile ()
 {
     FILE=$1
 
-    TMPFILE=$(mktemp -p /mnt/testarea -t Watch.XXXXX)
+    TMPFILE=$(mktemp -p /var/tmp -t Watch.XXXXX)
     while true; do
         if [ $JOURNALCTL = true ]; then
             journalctl -b > $FILE
@@ -76,7 +76,7 @@ echo "Dumping slabinfo - Stop - $timestamp" >> $SLABLOG
 logger -p local2.info -t "SlabCacheInfo" -f $SLABLOG
 
 if [ $JOURNALCTL = true ]; then
-    journalctl -b > /mnt/testarea/journalctl
+    journalctl -b > $LOGFILE
 fi
 
 # Submit dmesg log if any output

--- a/releasenotes/notes/replace-mnt-directory-15ff8cb75c2b3210.yaml
+++ b/releasenotes/notes/replace-mnt-directory-15ff8cb75c2b3210.yaml
@@ -1,0 +1,11 @@
+fixes:
+  - |
+    Use new task install default for non-RHTS package
+
+    For restraint-rhts package, tasks are installed and executed
+    beneath `/mnt/tests`.  For non-rhts `restraint`
+    installations, this path has changed to a more appropriate
+    location.
+
+    The `20_sysinfo` plugin processes journalctl log in a temporary location
+    instead of `/mnt` as it is just an interim event.

--- a/restraint.spec
+++ b/restraint.spec
@@ -324,10 +324,11 @@ fi
 /usr/share/%{name}/plugins/report_result.d
 /usr/share/%{name}/plugins/task_run.d
 /usr/share/%{name}/pkg_commands.d
-/var/lib/%{name}
 %if %{with_selinux_policy}
 %{_datadir}/selinux/packages/%{name}/restraint.pp
 %endif
+
+%dir /var/lib/%{name}
 
 %files client
 %attr(0755, root, root)%{_bindir}/%{name}
@@ -346,6 +347,7 @@ fi
 %attr(0755, root, root)%{_bindir}/rhts-lint
 %attr(0755, root, root)%{_bindir}/rhts-report-result
 %attr(0755, root, root)%{_bindir}/rhts-flush
+%config(noreplace)/var/lib/%{name}/install_config
 
 # Symlinks do not have attributes
 %{_bindir}/rhts-sync-set

--- a/src/recipe.c
+++ b/src/recipe.c
@@ -450,7 +450,7 @@ recipe_parse (xmlDoc *doc, SoupURI *recipe_uri, GError **error, gchar **cfg_file
     // Gather the location in which to install tasks
     result->base_path = get_install_dir(INSTALL_CONFIG_FILE, &tmp_error);
     if (tmp_error != NULL) {
-        g_warning("* Fail getting task install path using default. Error: %s",
+        g_warning("* Fail getting task install path. Using default. Error: %s",
                   tmp_error->message);
         g_clear_error(&tmp_error);
     }

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -23,9 +23,6 @@
 #include <libsoup/soup.h>
 #include <libxml/tree.h>
 
-// XXX make this configurable
-#define TASK_LOCATION "/mnt/tests"
-
 #define RECIPE_FETCH_INTERVAL 10
 #define RECIPE_FETCH_RETRIES 12
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -24,6 +24,10 @@
 #define CMD_ENV_DIR "/var/lib/restraint"
 #define CMD_ENV_FILE_FORMAT "%s/rstrnt-commands-env-%u.sh"
 
+#define INSTALL_CONFIG_FILE "/var/lib/restraint/install_config"
+#define INSTALL_DIR_VAR "INSTALL_DIR"
+#define INSTALL_DIR_DEFAULT "/var/lib/restraint/tests"
+
 #define STREQ(a, b) (g_strcmp0 (a, b) == 0)
 
 void update_env_file(gchar *prefix, gchar *restraint_url,
@@ -34,5 +38,6 @@ gchar *get_envvar_filename(guint port);
 guint64 parse_time_string (gchar *time_string, GError **error);
 gboolean file_exists (gchar *filename);
 gchar *get_package_version(gchar *pkg_name, GError **error);
+gchar * get_install_dir(const gchar *filename, GError **error);
 
 #endif


### PR DESCRIPTION
FIX: Use new task install default for non-RHTS package

For restraint-rhts package, tasks are installed and executed
beneath `/mnt/tests`.  For non-rhts `restraint`
installations, this path has changed to a more appropriate
location.

The `20_sysinfo` plugin processes journalctl log in a temporary location
instead of `/mnt` as it is just an interim event.

closes: 74
closes:105