### PR TITLE
Increase retries for recipe fetching

### DIFF
--- a/releasenotes/notes/increase-fetch-retries-a02b493029ebd3ab.yaml
+++ b/releasenotes/notes/increase-fetch-retries-a02b493029ebd3ab.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - |
+    Increase retries for recipe fetching
+    Retries for recipe fetching are increased from 3 attempts in 10
+    seconds intervals to 12 attempts in 10 seconds intervals.

--- a/src/Makefile
+++ b/src/Makefile
@@ -72,7 +72,7 @@ restraintd: server.o recipe.o task.o fetch.o fetch_git.o fetch_uri.o param.o rol
 fetch_git.o: fetch.h fetch_git.h
 fetch_uri.o: fetch.h fetch_uri.h
 task.o: task.h param.h role.h metadata.h process.h message.h dependency.h config.h errors.h fetch_git.h fetch_uri.h utils.h env.h xml.h
-recipe.o: recipe.h param.h role.h task.h server.h metadata.h utils.h config.h xml.h
+recipe.o: recipe.h param.h role.h task.h metadata.h utils.h config.h xml.h
 param.o: param.h
 role.o: role.h
 server.o: recipe.h task.h server.h

--- a/src/recipe.c
+++ b/src/recipe.c
@@ -26,7 +26,6 @@
 #include "param.h"
 #include "role.h"
 #include "task.h"
-#include "server.h"
 #include "metadata.h"
 #include "utils.h"
 #include "config.h"
@@ -510,10 +509,10 @@ fetch_completed(GError *error, xmlDoc *doc, gpointer user_data)
 
     if (error) {
         g_warn_if_fail(!doc);
-        if (app_data->fetch_retries < FETCH_RETRIES) {
+        if (app_data->fetch_retries < RECIPE_FETCH_RETRIES) {
             g_print("* RETRY [%d]**:%s\n", ++app_data->fetch_retries,
                     error->message);
-            g_timeout_add_seconds(FETCH_INTERVAL, fetch_retry, app_data);
+            g_timeout_add_seconds (RECIPE_FETCH_INTERVAL, fetch_retry, app_data);
         } else {
             g_propagate_prefixed_error(&app_data->error, error,
                     "While fetching recipe XML: ");

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -26,8 +26,8 @@
 // XXX make this configurable
 #define TASK_LOCATION "/mnt/tests"
 
-#define RECIPE_FETCH_RETRIES 3
 #define RECIPE_FETCH_INTERVAL 10
+#define RECIPE_FETCH_RETRIES 12
 
 extern SoupSession *soup_session;
 

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -26,6 +26,9 @@
 // XXX make this configurable
 #define TASK_LOCATION "/mnt/tests"
 
+#define RECIPE_FETCH_RETRIES 3
+#define RECIPE_FETCH_INTERVAL 10
+
 extern SoupSession *soup_session;
 
 typedef enum {

--- a/src/server.h
+++ b/src/server.h
@@ -24,8 +24,6 @@
 #define PLUGIN_SCRIPT "/usr/share/restraint/plugins/run_plugins"
 #define TASK_PLUGIN_SCRIPT "/usr/share/restraint/plugins/run_task_plugins"
 #define PLUGIN_DIR "/usr/share/restraint/plugins"
-#define FETCH_RETRIES 3
-#define FETCH_INTERVAL 10
 
 typedef enum {
   ABORTED_NONE,

--- a/src/task.c
+++ b/src/task.c
@@ -105,11 +105,11 @@ fetch_finish_callback (GError *error, guint32 match_cnt,
     GString *message = g_string_new (NULL);
 
     if (error) {
-        if (app_data->fetch_retries < FETCH_RETRIES) {
+        if (app_data->fetch_retries < TASK_FETCH_RETRIES) {
             g_warning("* RETRY fetch [%d]**:%s\n", ++app_data->fetch_retries,
                     error->message);
             g_clear_error(&error);
-            g_timeout_add_seconds(FETCH_INTERVAL, fetch_retry, app_data);
+            g_timeout_add_seconds (TASK_FETCH_INTERVAL, fetch_retry, app_data);
             return;
         } else {
             g_propagate_error (&task->error, error);
@@ -891,10 +891,10 @@ recipe_fetch_complete(GError *error, xmlDoc *doc, gpointer user_data)
     Task *task = app_data->tasks->data;
 
     if (error) {
-        if (app_data->fetch_retries < FETCH_RETRIES) {
+        if (app_data->fetch_retries < ROLE_REFRESH_RETRIES) {
             g_print("* RETRY refresh roles [%d]**:%s\n", ++app_data->fetch_retries,
                     error->message);
-            g_timeout_add_seconds(FETCH_INTERVAL, refresh_role_retry, app_data);
+            g_timeout_add_seconds (ROLE_REFRESH_INTERVAL, refresh_role_retry, app_data);
             return;
         } else {
             g_warn_if_fail(!doc);

--- a/src/task.h
+++ b/src/task.h
@@ -37,6 +37,12 @@
 #define LOG_PATH_HARNESS "logs/harness.log"
 #define LOG_PATH_TASK "logs/taskout.log"
 
+#define ROLE_REFRESH_INTERVAL 10
+#define ROLE_REFRESH_RETRIES 3
+
+#define TASK_FETCH_INTERVAL 10
+#define TASK_FETCH_RETRIES 3
+
 typedef enum {
     TASK_IDLE,
     TASK_FETCH,


### PR DESCRIPTION
As reported in #101, there are some corner cases where recipe fetching takes more than 30 seconds, somewhere close 60 seconds. Increasing the number of recipe fetching retries, so it keeps trying over 60 seconds, should cover this case.

- Refactor retry macro pairs, so values can be defined per operation, recipe fetching, tasks fetching and role refreshing
- Increase recipe fetching retries from 3 to 12. With a 10 seconds interval, from 30 to 120 seconds

Fixes #101 