### PR TITLE
Fix time_chged leak in server_recipe_callback

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -364,7 +364,10 @@ server_recipe_callback (SoupServer *server, SoupMessage *client_msg,
                        "'no_localwatchdog' metadata is set");
         } else {
             task->remaining_time = max_time;
-            task->time_chged = g_malloc (sizeof (time_t));
+
+            if (task->time_chged == NULL)
+                task->time_chged = g_malloc (sizeof (time_t));
+
             *task->time_chged = time (NULL);
         }
 

--- a/src/server.c
+++ b/src/server.c
@@ -312,10 +312,6 @@ server_recipe_callback (SoupServer *server, SoupMessage *client_msg,
     SoupURI *server_uri;
     SoupMessageHeadersIter iter;
     const gchar *name, *value;
-    GHashTable *new_table;
-    guint64 max_time = 0;
-    gchar *form_data;
-    gchar *form_seconds;
 
     ClientData *client_data = g_slice_new0 (ClientData);
     client_data->path = path;
@@ -343,7 +339,11 @@ server_recipe_callback (SoupServer *server, SoupMessage *client_msg,
         server_msg = soup_message_new_from_uri ("PUT", server_uri);
     } else if (g_str_has_suffix (path, "watchdog")) {
         GHashTable *data_table;
+        GHashTable *new_table;
+        gchar      *form_data;
+        gchar      *form_seconds;
         gchar      *seconds_string;
+        guint64     max_time = 0;
 
         // Extract the number of watchdog seconds
         data_table = soup_form_decode(client_msg->request_body->data);

--- a/src/server.c
+++ b/src/server.c
@@ -338,14 +338,14 @@ server_recipe_callback (SoupServer *server, SoupMessage *client_msg,
         g_free (uri);
         server_msg = soup_message_new_from_uri ("PUT", server_uri);
     } else if (g_str_has_suffix (path, "watchdog")) {
-        GHashTable *data_table;
+        GHashTable *form_data;
         gchar      *encoded_form;
         gchar      *seconds_string;
         guint64     max_time;
 
         // Extract the number of watchdog seconds
-        data_table = soup_form_decode(client_msg->request_body->data);
-        seconds_string = g_hash_table_lookup(data_table, "seconds");
+        form_data = soup_form_decode (client_msg->request_body->data);
+        seconds_string = g_hash_table_lookup (form_data, "seconds");
 
         if (seconds_string != NULL) {
             max_time = g_ascii_strtoull (seconds_string, NULL, BASE10);
@@ -356,7 +356,7 @@ server_recipe_callback (SoupServer *server, SoupMessage *client_msg,
             max_time = 0;
         }
 
-        g_hash_table_destroy (data_table);
+        g_hash_table_destroy (form_data);
 
         // Update the number of watchdog seconds for External watchdog
         // by increasing it by EWD_TIME

--- a/src/server.c
+++ b/src/server.c
@@ -388,13 +388,9 @@ server_recipe_callback (SoupServer *server, SoupMessage *client_msg,
             g_warning("Adjustment to local watchdog ignored since 'no_localwatchdog'"
                       " metadata is set\n");
         } else {
-            task->remaining_time = 0;
-            if (max_time > 0) {
-                task->remaining_time = max_time;
-            }
-            time_t rawtime;
-            time(&rawtime);
-            task->time_chged = g_memdup(&rawtime, sizeof(time_t));
+            task->remaining_time = max_time;
+            task->time_chged = g_malloc (sizeof (time_t));
+            *task->time_chged = time (NULL);
         }
     } else if (g_str_has_suffix(path, "status")) {
         gchar **splitpath = g_strsplit(path, "/", -1);


### PR DESCRIPTION
A request to adjust watchdog will take up to HEARTBEAT time to get the value updated. As time_chged is freed and set to NULL only after the value is updated, every request to adjust the watchdog sent before this will cause a leak:

```
==8587== 40 bytes in 5 blocks are definitely lost in loss record 1,629 of 2,470
==8587==    at 0x483A809: malloc (vg_replace_malloc.c:307)
==8587==    by 0x6219B8: g_malloc (gmem.c:99)
==8587==    by 0x636A81: g_memdup (gstrfuncs.c:391)
==8587==    by 0x40A3AE: server_recipe_callback (server.c:397)
==8587==    by 0x5C7DD9: g_closure_invoke (gclosure.c:804)
==8587==    by 0x5DA2F2: signal_emit_unlocked_R.isra.0 (gsignal.c:3635)
==8587==    by 0x5E094A: g_signal_emit_valist (gsignal.c:3391)
==8587==    by 0x5E0B92: g_signal_emit (gsignal.c:3447)
==8587==    by 0x4C2CF3: io_read (soup-message-io.c:726)
==8587==    by 0x4C3245: io_run_until (soup-message-io.c:922)
==8587==    by 0x4C3CE3: io_run (soup-message-io.c:993)
==8587==    by 0x4EDEA3: soup_message_read_request (soup-message-server-io.c:275)
```

https://github.com/beaker-project/restraint/blob/b802fb406397bc3eb4c8303886a086fdbb47ce4b/src/server.c#L397

- Only allocate time_chged if the variable is NULL
- Remove unnecessary logic for LWD adjust
- Remove unnecessary variables
- Rename variables and fix style
- Adjust LWD after value is extracted