### PR TITLE
fix: Don't override task max_time if time parsing fails

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -354,8 +354,13 @@ task_finish_callback (gint pid_result, gboolean localwatchdog, gpointer user_dat
 static void
 check_param_for_override (Param *param, Task *task)
 {
-    if (g_strcmp0 (param->name, "KILLTIMEOVERRIDE") == 0 ||
-        g_strcmp0 (param->name, "RSTRNT_MAX_TIME") == 0) {
+    const gchar *name;
+
+    g_return_if_fail (param != NULL && task != NULL);
+
+    name = param->name;
+
+    if (STREQ (name, "KILLTIMEOVERRIDE") || STREQ (name, "RSTRNT_MAX_TIME")) {
         GError  *error = NULL;
         guint64  time_value;
 
@@ -367,15 +372,12 @@ check_param_for_override (Param *param, Task *task)
             g_warning ("'max_time' override failed: %s", error->message);
             g_clear_error (&error);
         }
-    }
-    if (g_strcmp0 (param->name, "RSTRNT_USE_PTY") == 0) {
-        gchar *value = g_ascii_strup(param->value, -1);
-        if (g_strcmp0 (value, "TRUE") == 0) {
-            task->metadata->use_pty = TRUE;
-        } else {
-            task->metadata->use_pty = FALSE;
-        }
-        g_free(value);
+    } else if (STREQ (name, "RSTRNT_USE_PTY")) {
+        gchar *value = g_ascii_strup (param->value, -1);
+
+        task->metadata->use_pty = STREQ (value, "TRUE");
+
+        g_free (value);
     }
 }
 

--- a/src/task.c
+++ b/src/task.c
@@ -356,7 +356,17 @@ check_param_for_override (Param *param, Task *task)
 {
     if (g_strcmp0 (param->name, "KILLTIMEOVERRIDE") == 0 ||
         g_strcmp0 (param->name, "RSTRNT_MAX_TIME") == 0) {
-        task->remaining_time = parse_time_string (param->value, NULL);
+        GError  *error = NULL;
+        guint64  time_value;
+
+        time_value = parse_time_string (param->value, &error);
+
+        if (error == NULL) {
+            task->remaining_time = time_value;
+        } else {
+            g_warning ("'max_time' override failed: %s", error->message);
+            g_clear_error (&error);
+        }
     }
     if (g_strcmp0 (param->name, "RSTRNT_USE_PTY") == 0) {
         gchar *value = g_ascii_strup(param->value, -1);

--- a/src/test_utils.c
+++ b/src/test_utils.c
@@ -259,6 +259,73 @@ test_environment_file (void)
     g_assert_false(check_env_file_present(port));
 }
 
+static void
+test_parse_time_string_units (void)
+{
+    GError *tmp_error = NULL;
+
+    g_assert_true (parse_time_string ("1d", &tmp_error) == 60 * 60 * 24);
+    g_assert_no_error (tmp_error);
+
+    g_assert_true (parse_time_string ("1h", &tmp_error) == 60 * 60);
+    g_assert_no_error (tmp_error);
+
+    g_assert_true (parse_time_string ("1m", &tmp_error) == 60);
+    g_assert_no_error (tmp_error);
+
+    g_assert_true (parse_time_string ("1s", &tmp_error) == 1);
+    g_assert_no_error (tmp_error);
+
+    g_assert_true (parse_time_string ("1", &tmp_error) == 1);
+    g_assert_no_error (tmp_error);
+}
+
+static void
+test_parse_time_string_wrong_unit (void)
+{
+    GError *tmp_error = NULL;
+
+    g_assert_true (parse_time_string ("1x", &tmp_error) == 1);
+    g_assert_nonnull (tmp_error);
+
+    g_clear_error (&tmp_error);
+}
+
+static void
+test_parse_time_string_wrong_string (void)
+{
+    GError *tmp_error = NULL;
+
+    g_assert_true (parse_time_string ("One day", &tmp_error) == 0);
+    g_assert_nonnull (tmp_error);
+
+    g_clear_error (&tmp_error);
+
+    g_assert_true (parse_time_string ("d", &tmp_error) == 0);
+    g_assert_nonnull (tmp_error);
+
+    g_clear_error (&tmp_error);
+}
+
+static void
+test_parse_time_string (void)
+{
+    GError  *tmp_error = NULL;
+    guint64  expected_seconds = 30 * 60 * 60;
+
+    g_assert_true (expected_seconds == parse_time_string ("30h", &tmp_error));
+    g_assert_no_error (tmp_error);
+
+    g_assert_true (expected_seconds == parse_time_string ("30H", &tmp_error));
+    g_assert_no_error (tmp_error);
+
+    g_assert_true (expected_seconds == parse_time_string ("30 h", &tmp_error));
+    g_assert_no_error (tmp_error);
+
+    g_assert_true (expected_seconds == parse_time_string ("30 H", &tmp_error));
+    g_assert_no_error (tmp_error);
+}
+
 int
 main (int   argc,
       char *argv[])
@@ -275,6 +342,14 @@ main (int   argc,
                      test_get_package_version_stderr);
     g_test_add_func ("/utils/test_environment_file",
                      test_environment_file);
+    g_test_add_func ("/utils/parse_time_string",
+                     test_parse_time_string);
+    g_test_add_func ("/utils/parse_time_string/recognized_units",
+                     test_parse_time_string_units);
+    g_test_add_func ("/utils/parse_time_string/wrong_unit",
+                     test_parse_time_string_wrong_unit);
+    g_test_add_func ("/utils/parse_time_string/wrong_string",
+                     test_parse_time_string_wrong_string);
 
     return g_test_run ();
 }

--- a/src/test_utils.c
+++ b/src/test_utils.c
@@ -285,7 +285,7 @@ test_parse_time_string_wrong_unit (void)
 {
     GError *tmp_error = NULL;
 
-    g_assert_true (parse_time_string ("1x", &tmp_error) == 1);
+    g_assert_true (parse_time_string ("1x", &tmp_error) == 0);
     g_assert_nonnull (tmp_error);
 
     g_clear_error (&tmp_error);

--- a/src/utils.c
+++ b/src/utils.c
@@ -75,6 +75,8 @@ remove_env_file(guint port)
  *     3m -> 180
  *     2h -> 7200
  *     600s -> 600
+ *
+ * If parsing fails, error is set and 0 is returned.
  */
 guint64
 parse_time_string (gchar *time_string, GError **error)
@@ -120,7 +122,7 @@ parse_time_string (gchar *time_string, GError **error)
         break;
     }
 
-    return time_value;
+    return 0;
 }
 
 gboolean

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,4 +1,4 @@
-/*  
+/*
     This file is part of Restraint.
 
     Restraint is free software: you can redistribute it and/or modify
@@ -23,6 +23,8 @@
 
 #define CMD_ENV_DIR "/var/lib/restraint"
 #define CMD_ENV_FILE_FORMAT "%s/rstrnt-commands-env-%u.sh"
+
+#define STREQ(a, b) (g_strcmp0 (a, b) == 0)
 
 void update_env_file(gchar *prefix, gchar *restraint_url,
                      gchar *recipe_id, gchar *task_id,


### PR DESCRIPTION
In check_param_for_override, the whatchdog time is updated if the environment variables KILLTIMEOVERRIDE or STRNT_MAX_TIME are set. The value was used from parse_time_string without checking if the parsing succeeded.

- Add tests for parse_time_string
- Refactor parse_time_string
- Don't override task max_time if parse_time_string fails