### PR TITLE
Allow text to wrap in tables

### DIFF
--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -1,0 +1,13 @@
+/* override table width restrictions */
+@media screen and (min-width: 767px) {
+
+   .wy-table-responsive table td {
+      /* !important prevents the common CSS stylesheets from overriding
+         this as on ReadTheDocs they are loaded after this stylesheet */
+      white-space: normal !important;
+   }
+
+   .wy-table-responsive {
+      overflow: visible !important;
+   }
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -125,8 +125,13 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
-html_static_path = []
+html_static_path = ['_static']
+
+html_context = {
+    'css_files': [
+        '_static/theme_overrides.css',  # override wide tables in RTD theme
+        ],
+     }
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/remove_rhts.rst
+++ b/docs/remove_rhts.rst
@@ -39,10 +39,10 @@ Included in the table are the `Restraint` substitutes and which RHTS commands ar
 +--------------------------------+-------------------------------------------+
 | rhts-backup                    | rstrnt-backup                             |
 +--------------------------------+-------------------------------------------+
-| rhts-db-submit-result,         | rstrnt-report-result.d plugin             |
+| rhts-db-submit-result          | rstrnt-report-result.d plugin             |
 | rhts_db_submit_result          | :ref:`rpt_result` (See Note)              |
 +--------------------------------+-------------------------------------------+
-| rhts-environment.sh,           | None                                      |
+| rhts-environment.sh            | None                                      |
 | rhts_environment.sh            |                                           |
 +--------------------------------+-------------------------------------------+
 | rhts-extend                    | rstrnt-adjust-watchdog                    |
@@ -55,10 +55,10 @@ Included in the table are the `Restraint` substitutes and which RHTS commands ar
 +--------------------------------+-------------------------------------------+
 | rhts-reboot                    | rstrnt-reboot                             |
 +--------------------------------+-------------------------------------------+
-| rhts-recipe-sync-block,        | rstrnt-sync-block                         |
+| rhts-recipe-sync-block         | rstrnt-sync-block                         |
 | rhts_recipe_sync_block         |                                           |
 +--------------------------------+-------------------------------------------+
-| rhts-recipe-sync-set,          | rstrnt-sync-set                           |
+| rhts-recipe-sync-set           | rstrnt-sync-set                           |
 | rhts_recipe_sync_set           |                                           |
 +--------------------------------+-------------------------------------------+
 | rhts-report-result             | rstrnt-report-result                      |
@@ -67,13 +67,13 @@ Included in the table are the `Restraint` substitutes and which RHTS commands ar
 +--------------------------------+-------------------------------------------+
 | rhts-run-simple-test           | None                                      |
 +--------------------------------+-------------------------------------------+
-| rhts-submit-log,               | rstrnt-report-log                         |
+| rhts-submit-log                | rstrnt-report-log                         |
 | rhts_submit_log                |                                           |
 +--------------------------------+-------------------------------------------+
-| rhts-sync-block,               | rstrnt-sync-block                         |
+| rhts-sync-block                | rstrnt-sync-block                         |
 | rhts_sync_block                |                                           |
 +--------------------------------+-------------------------------------------+
-| rhts-sync-set,                 | rstrnt-sync-set                           |
+| rhts-sync-set                  | rstrnt-sync-set                           |
 | rhts_sync_set                  |                                           |
 +--------------------------------+-------------------------------------------+
 | rhts-system-info               | localwatchdog.d 20_sysinfo plugin         |


### PR DESCRIPTION
There is a known bug where `readthedocs` doesn't allow table cells
to wrap.  As a result, the horizontal scroll bars are very long
making it difficult to view the table.  Details on this fix
was found from:
https://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html
This anomaly is only with `readthedocs` and not seen with local
doc generation and viewing.

Fixes: #108