### PR TITLE
containers: Add script to build rpms in containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ rel-eng/lib/__pycache__/
 tags
 cscope.out
 .tox/
+tito-test-build/

--- a/containers/provision/centos:8.sh
+++ b/containers/provision/centos:8.sh
@@ -9,7 +9,8 @@ dnf install -y 'dnf-command(config-manager)' \
 	       python3-flask \
 	       python3-requests \
 	       python3-pytest \
-	       python3-six
+	       python3-six \
+	       epel-release
 
 dnf config-manager -y --enable PowerTools
 

--- a/containers/utils/build-rpms.sh
+++ b/containers/utils/build-rpms.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+RESTRAINT_DIR=/restraint
+RPMBUILD_DIR="$RESTRAINT_DIR"/tito-test-build
+
+cd $RESTRAINT_DIR || exit
+
+dnf -y install tito || exit
+
+tito build --rpmbuild-options="--without static" --test --rpm -o "$RPMBUILD_DIR"


### PR DESCRIPTION
Can be used by running,
```
 $ containers/run.sh ./containers/utils/build-rpms.sh
```
After build, packages will be available in the restraint/tito-test-build directory.

Works for CentOS 8, Fedora 31 and Fedora 32.

Fedora Rawhide works at the time of this PR.