### PR TITLE
FIX: `SKIP` results fail for non-rhts tasks

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -153,7 +153,7 @@ The following are examples of each method using the command `rstrnt-abort` as an
 
 rstrnt-abort
 ~~~~~~~~~~~~
-Running this command sets a recipe or a task to `Aborted` status. For an aborted recipe, the current
+Running this command sets a recipe to `Aborted` status. As a result, the current
 task as well as subsequent tasks in the recipe will be marked as `aborted` and the job is discontinued.
 
 Arguments for this command are as follows::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,6 +48,7 @@ Contents:
    jobs
    tasks
    variables
+   results
    plugins
    using
    release-notes

--- a/docs/remove_rhts.rst
+++ b/docs/remove_rhts.rst
@@ -18,6 +18,13 @@ to eliminate RHTS references.
    on how your task is written, you may have to update or remove `Makefiles` so they
    do not process the `testinfo.desc` file.  An example of this is also
    included in the referenced section.
+#. The final results for a task is influenced by whether your task is defined with
+   a `metadata` file (non-rhts) versus `Makefile/testinfo.desc` (rhts).  If a task
+   exits with a zero and the user did not call rstrnt-report-result,
+   the task will conclude with `PASS` instead of `New` making sure there is some
+   valid conclusion to this task.  If task exits with non-zero, the task will
+   result with `FAIL` for non-rhts instead of `ABORT`.  For further details,
+   refer to :ref:`task_results`.
 #. Replace `RHTS` environment variables with `Restraint` variables. A table listing
    `RHTS Legacy Variables` to `Restraint Substitute` can be found in
    :ref:`legacy_env_var`.

--- a/docs/results.rst
+++ b/docs/results.rst
@@ -1,0 +1,27 @@
+.. _task_results:
+
+Task Results
+------------
+The final result outcome of a task is influenced by what is set when calling
+`rstrnt-report-result`, `rstrnt-abort`, and the return code the task exits with.
+
+The user controls the output of the task by calling `rstrnt-report-result` with
+test results of `SKIP|PASS|WARN|FAIL` (listed by severity). It can be called multiple
+times in the same task but the final task result wlll be the highest severity
+reported so long as the task exits with zero. With these results, the job
+will go on to the next task.
+
+If the user also `rstrnt-abort`, this take precedence over the calls to
+`rstrnt-report-results`. The final task result will be `abort` and the job
+will not go on to the next task.
+
+There is a deviation in behavior when a non-zero exit code is returned by the task.
+If the legacy `Makefile/testinfo` file is present in the user's task, the final
+task result is `ABORT` regardless of the restraint command calls the user makes.
+If the `metadata` file is present in the user's task, the final task result is FAIL.
+If the user still wants the legacy behavior, they can call the `rstrnt-abort` command
+in their task.
+
+For more details in regard to the command `rstrnt-report-result` and `rstrnt-abort`
+refer to `restraintd` command section :ref:`restraintd_intro`.
+

--- a/releasenotes/notes/SKIP-issue-nonrhts-task-7e414a198ce0cbb5.yaml
+++ b/releasenotes/notes/SKIP-issue-nonrhts-task-7e414a198ce0cbb5.yaml
@@ -1,0 +1,20 @@
+fixes:
+  - |
+    Recognize results reported for non-rhts tasks
+
+    When the task reports just `SKIP` for results, the final task result
+    should be `SKIP`. An extra task result is occurring when a non-rhts task
+    is executed.  An non-rhts task is one that uses the `metadata` file
+    instead of `testinfo` file.  Bugzilla 1334893 made a change to always
+    report results `PASS` for task exiting with zero or `FAIL` when
+    exit non-zero for non-rhts tasks.  As a result, `PASS` was being
+    reported which has a high priority then `SKIP` so the final task
+    result was `PASS`
+
+    Code changes monitor whether user reports results by way of
+    `rstrnt-report-result`.  If so, give those results priority; otherwise,
+    hardcode `PASS` task result for user.
+
+    When process exits with non-zero, `FAIL` for non-rhts will remain as this
+    provides the user the option to continue with the job.  If they want
+    legacy behavior, they should make a call to `rstrnt-abort` in their task.

--- a/src/server.c
+++ b/src/server.c
@@ -334,6 +334,9 @@ server_recipe_callback (SoupServer *server, SoupMessage *client_msg,
     if (g_str_has_suffix (path, "/results/")) {
         server_uri = soup_uri_new_with_base (task->task_uri, "results/");
         server_msg = soup_message_new_from_uri ("POST", server_uri);
+        if (task != NULL) {
+            task->results_reported = TRUE;
+        }
     } else if (g_strrstr (path, "/logs/") != NULL) {
         gchar *uri = soup_uri_to_string(task->task_uri, FALSE);
         gchar *log_url = swap_base(path, uri, "/recipes/");

--- a/src/task.c
+++ b/src/task.c
@@ -281,8 +281,9 @@ task_finish_callback (gint pid_result, gboolean localwatchdog, gpointer user_dat
     if (pid_result == 0) {
         task->state = task_run_data->pass_state;
 
-        // If not running in rhts compat mode report PASS for exit code 0
-        if (!task->rhts_compat) {
+        // If not running in rhts compat mode and user hasn't reported results,
+        // report PASS for exit code 0.
+        if (!task->rhts_compat && !task->results_reported) {
             restraint_task_result(task, app_data, "PASS", 0, "exit_code", NULL);
         }
     } else {

--- a/src/task.h
+++ b/src/task.h
@@ -96,6 +96,8 @@ typedef struct {
     gboolean started;
     /* Has this task finished already? */
     gboolean finished;
+    /* Has this task reported results? */
+    gboolean results_reported;
     /* Has this task triggered the localwatchdog? */
     gboolean localwatchdog;
     /* Are we running in rhts_compat mode? */


### PR DESCRIPTION
When the task reports just `SKIP` for results, the final task result
should be `SKIP`. When a non-rhts task is running, an extra task result
of `PASS` is occurring. Since `PASS` has a higher severity than `SKIP`,
`PASS` becomes the final task result. (note: a non-rhts task is one
defined using `metadata` file instead of `Makefile/testinfo` file.)
Bugzilla 1334893 made a change to always report results `PASS` or
`FAIL` for non-rhts tasks based on the process exit results without
considering results from user calls to `rstrnt-report-result`.

New Behavior when task process exits successfully:
Code changes monitor whether the user reports results by way of
`rstrnt-report-result`.  If so, give user `reported` results
priority; otherwise, provide a `PASS` task result for user.

Behavior when process does not exit successfully:
The intent of Bugzilla 1334893 was to make sure there is a final
task result. Normally when a non-zero process result is returned,
an error message is generated.  When the task is processed in
the COMPLETED state, this is translated as an abort.  For non-rhts
the result instead is FAIL.  This gives the user the option
to continue their job; otherwise, the user will
have to call rstrnt-abort is they want legacy behavior to stop
executing the remainder of the job.

Bug: 1855013