### PR TITLE
Log manager for log caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@
 /src/test_cmd_utils
 /src/test_cmd_watchdog
 /src/test_fetch_task
+/src/test_logging
+/src/test_logging_logs/
 /src/test_metadata
 /src/test_recipe
 /src/test_task

--- a/releasenotes/notes/log-manager-18fb90743f423087.yaml
+++ b/releasenotes/notes/log-manager-18fb90743f423087.yaml
@@ -1,0 +1,6 @@
+features:
+  - |
+    Log manager for log caching
+    When Restraint runs under Beaker, harness and task logs are cached
+    in the system. Logs are uploaded to Beaker after the task completes.
+    Contributed by Ernestas Kulik <ernestask@gnome.org>

--- a/src/Makefile
+++ b/src/Makefile
@@ -180,4 +180,4 @@ install: all
 
 .PHONY: clean
 clean:
-	rm -f $(PROGRAMS) $(TEST_PROGRAMS) *.o rstrnt-commands-env-*.sh
+	rm -rf $(PROGRAMS) $(TEST_PROGRAMS) *.o rstrnt-commands-env-*.sh test_logging_logs/

--- a/src/Makefile
+++ b/src/Makefile
@@ -66,7 +66,7 @@ rstrnt-sync: cmd_sync.o
 restraint: client.o errors.o xml.o utils.o process.o restraint_forkpty.o
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
 
-restraintd: server.o recipe.o task.o fetch.o fetch_git.o fetch_uri.o param.o role.o metadata.o process.o message.o dependency.o utils.o config.o errors.o xml.o env.o restraint_forkpty.o beaker_harness.o
+restraintd: server.o recipe.o task.o fetch.o fetch_git.o fetch_uri.o param.o role.o metadata.o process.o message.o dependency.o utils.o config.o errors.o xml.o env.o restraint_forkpty.o beaker_harness.o logging.o
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 fetch_git.o: fetch.h fetch_git.h
@@ -89,6 +89,7 @@ errors.o: errors.h
 xml.o: xml.h
 restraint_forkpty.o:
 beaker_harness.o:
+logging.o: logging.c logging.h task.h
 
 # Tests
 TEST_PROGRAMS += test_beaker_harness
@@ -106,6 +107,7 @@ TEST_PROGRAMS += test_process
 #TEST_PROGRAMS += test_recipe
 #TEST_PROGRAMS += test_task
 TEST_PROGRAMS += test_utils
+TEST_PROGRAMS += test_logging
 
 test_%: test_%.o
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
@@ -156,6 +158,9 @@ test_cmd_watchdog.o: cmd_watchdog.h utils.h cmd_utils.h errors.h
 test_cmd_utils: test_cmd_utils.o cmd_utils.o env.o utils.o errors.o
 
 test_utils: test_utils.o utils.o errors.o
+
+test_logging: test_logging.o message.o
+test_logging.o: test_logging.c
 
 test-data/git-remote: test-data/git-remote.tgz
 	tar --no-same-owner -C test-data -xzf $<

--- a/src/Makefile
+++ b/src/Makefile
@@ -160,7 +160,7 @@ test_cmd_utils: test_cmd_utils.o cmd_utils.o env.o utils.o errors.o
 test_utils: test_utils.o utils.o errors.o
 
 test_logging: test_logging.o message.o
-test_logging.o: test_logging.c
+test_logging.o: test_logging.c logging.c
 
 test-data/git-remote: test-data/git-remote.tgz
 	tar --no-same-owner -C test-data -xzf $<

--- a/src/beaker_harness.h
+++ b/src/beaker_harness.h
@@ -18,6 +18,8 @@
 #ifndef _RESTRAINT_BEAKER_HARNESS_H
 #define _RESTRAINT_BEAKER_HARNESS_H
 
+#define BKR_MAX_CONTENT_LENGTH 10 * 1024 * 1024  /* 10MB */
+
 #define BKR_ENV_EXISTS()           (rstrnt_bkr_env_exists () != 0)
 #define BKR_RECIPE_IS_HEALTHY(url) (BKR_HEALTH_STATUS_GOOD == rstrnt_bkr_check_recipe (url))
 

--- a/src/logging.c
+++ b/src/logging.c
@@ -18,6 +18,10 @@
 #include "logging.h"
 #include "task.h"
 
+#ifndef LOG_MANAGER_DIR
+#define LOG_MANAGER_DIR VAR_LIB_PATH "/logs"
+#endif
+
 struct _RstrntLogManager
 {
     GObject parent_instance;
@@ -165,9 +169,7 @@ rstrnt_task_log_data_new (const RstrntTask  *task,
     g_autoptr (GFileOutputStream) harness_log_file_output_stream = NULL;
     RstrntTaskLogData *data;
 
-    log_directory_path = g_build_path ("/",
-                                       VAR_LIB_PATH, "logs", task->task_id,
-                                       NULL);
+    log_directory_path = g_build_path ("/", LOG_MANAGER_DIR, task->task_id, NULL);
     log_directory = g_file_new_for_path (log_directory_path);
 
     if (!g_file_make_directory_with_parents (log_directory, NULL, error))

--- a/src/logging.c
+++ b/src/logging.c
@@ -144,12 +144,13 @@ rstrnt_write_log_func (gpointer data,
     bool success;
 
     writer_data = data;
+    variant = writer_data->variant;
 
-    message = g_variant_get_fixed_array (writer_data->variant, &message_length,
-                                         sizeof(*message));
+    message = g_variant_get_fixed_array (variant, &message_length, sizeof (*message));
     success = g_output_stream_write_all (G_OUTPUT_STREAM (writer_data->log_data->output_stream),
                                          message, message_length,
                                          NULL, NULL, &error);
+
     if (!success)
     {
         g_warning ("%s(): Failed to write out log message: %s",
@@ -411,6 +412,7 @@ rstrnt_log_manager_append_to_log (RstrntLogManager    *self,
 
             break;
     }
+
     writer_data->variant = g_variant_new_fixed_array (G_VARIANT_TYPE_BYTE,
                                                       message, message_length,
                                                       sizeof(*message));

--- a/src/logging.c
+++ b/src/logging.c
@@ -1,0 +1,466 @@
+#include "logging.h"
+#include "task.h"
+
+struct _RstrntLogManager
+{
+    GObject parent_instance;
+
+    GHashTable *logs;
+};
+
+G_DEFINE_TYPE (RstrntLogManager, rstrnt_log_manager, G_TYPE_OBJECT)
+
+typedef struct
+{
+    GFile *file;
+    GFileOutputStream *output_stream;
+} RstrntLogData;
+
+typedef struct
+{
+    RstrntLogData *log_data;
+    GVariant *variant;
+} RstrntLogWriterData;
+
+typedef struct
+{
+    RstrntLogData *task_log_data;
+    RstrntLogData *harness_log_data;
+
+    GThreadPool *thread_pool;
+} RstrntTaskLogData;
+
+static void
+rstrnt_log_manager_dispose (GObject *object)
+{
+    RstrntLogManager *self;
+
+    self = RSTRNT_LOG_MANAGER (object);
+
+    if (NULL != self->logs)
+    {
+        g_hash_table_destroy (self->logs);
+        self->logs = NULL;
+    }
+
+    G_OBJECT_CLASS (rstrnt_log_manager_parent_class)->dispose (object);
+}
+
+static void
+rstrnt_log_manager_class_init (RstrntLogManagerClass *klass)
+{
+    GObjectClass *object_class;
+
+    object_class = G_OBJECT_CLASS (klass);
+
+    object_class->dispose = rstrnt_log_manager_dispose;
+}
+
+static void
+rstrnt_log_data_destroy (gpointer data)
+{
+    RstrntLogData *log_data;
+
+    log_data = data;
+
+    g_clear_object (&log_data->output_stream);
+    g_clear_object (&log_data->file);
+
+    g_free (log_data);
+}
+
+static void
+rstrnt_task_log_data_destroy (gpointer data)
+{
+    RstrntTaskLogData *task_log_data;
+
+    task_log_data = data;
+
+    rstrnt_log_data_destroy (task_log_data->task_log_data);
+    rstrnt_log_data_destroy (task_log_data->harness_log_data);
+    g_thread_pool_free (task_log_data->thread_pool, TRUE, TRUE);
+
+    g_free (task_log_data);
+}
+
+static void
+rstrnt_log_manager_init (RstrntLogManager *self)
+{
+    self->logs = g_hash_table_new_full (g_str_hash, g_str_equal,
+                                        NULL, rstrnt_task_log_data_destroy);
+}
+
+static RstrntLogData *
+rstrnt_log_data_new (GFile   *file,
+                     GError **error)
+{
+    RstrntLogData *data;
+
+    data = g_new0 (RstrntLogData, 1);
+
+    data->file = g_object_ref (file);
+    data->output_stream = g_file_append_to (data->file, G_FILE_CREATE_NONE,
+                                            NULL, error);
+    if (NULL == data->output_stream)
+    {
+        rstrnt_log_data_destroy (data);
+
+        return NULL;
+    }
+
+    return data;
+}
+
+static void
+rstrnt_write_log_func (gpointer data,
+                       gpointer user_data)
+{
+    g_autofree RstrntLogWriterData *writer_data = NULL;
+    g_autoptr (GVariant) variant = NULL;
+    const char *message;
+    gsize message_length;
+    GError *error = NULL;
+    bool success;
+
+    writer_data = data;
+
+    message = g_variant_get_fixed_array (writer_data->variant, &message_length,
+                                         sizeof(*message));
+    success = g_output_stream_write_all (G_OUTPUT_STREAM (writer_data->log_data->output_stream),
+                                         message, message_length,
+                                         NULL, NULL, &error);
+    if (!success)
+    {
+        g_warning ("%s(): Failed to write out log message: %s",
+                   __func__, error->message);
+    }
+}
+
+static RstrntTaskLogData *
+rstrnt_task_log_data_new (const RstrntTask  *task,
+                          GError           **error)
+{
+    g_autofree char *log_directory_path = NULL;
+    g_autoptr (GFile) log_directory = NULL;
+    g_autoptr (GFile) task_log_file = NULL;
+    g_autoptr (GFileOutputStream) task_log_file_output_stream = NULL;
+    g_autoptr (GFile) harness_log_file = NULL;
+    g_autoptr (GFileOutputStream) harness_log_file_output_stream = NULL;
+    RstrntTaskLogData *data;
+
+    log_directory_path = g_build_path ("/",
+                                       VAR_LIB_PATH, "logs", task->task_id,
+                                       NULL);
+    log_directory = g_file_new_for_path (log_directory_path);
+
+    if (!g_file_make_directory_with_parents (log_directory, NULL, error))
+    {
+        if (NULL != error && G_IO_ERROR_EXISTS != (*error)->code)
+        {
+            return NULL;
+        }
+
+        g_clear_error (error);
+    }
+
+    task_log_file = g_file_get_child (log_directory, "task.log");
+    harness_log_file = g_file_get_child (log_directory, "harness.log");
+    data = g_new0 (RstrntTaskLogData, 1);
+
+    data->task_log_data = rstrnt_log_data_new (task_log_file, error);
+    if (NULL == data->task_log_data)
+    {
+        rstrnt_task_log_data_destroy (data);
+
+        return NULL;
+    }
+    data->harness_log_data = rstrnt_log_data_new (harness_log_file, error);
+    if (NULL == data->harness_log_data)
+    {
+        rstrnt_task_log_data_destroy (data);
+
+        return NULL;
+    }
+    data->thread_pool = g_thread_pool_new (rstrnt_write_log_func, NULL, 1,
+                                           FALSE, error);
+    if (NULL == data->thread_pool)
+    {
+        rstrnt_task_log_data_destroy (data);
+
+        return NULL;
+    }
+
+    return data;
+}
+
+static RstrntTaskLogData *
+rstrnt_log_manager_get_task_data (RstrntLogManager  *self,
+                                  const RstrntTask  *task,
+                                  GError           **error)
+{
+    RstrntTaskLogData *data;
+
+    data = g_hash_table_lookup (self->logs, task->task_id);
+    if (NULL == data)
+    {
+        data = rstrnt_task_log_data_new (task, error);
+        if (NULL != data)
+        {
+            (void) g_hash_table_insert (self->logs, task->task_id, data);
+        }
+    }
+
+    return data;
+}
+
+static void
+rstrnt_on_log_uploaded (SoupSession *session,
+                        SoupMessage *msg,
+                        gpointer     user_data)
+{
+    g_debug ("%s(): response code: %u", __func__, msg->status_code);
+
+    g_mapped_file_unref (user_data);
+}
+
+static void
+rstrnt_flush_logs (const RstrntTask *task,
+                   GCancellable     *cancellable)
+{
+    RstrntLogManager *manager;
+    RstrntTaskLogData *data;
+    GOutputStream *stream;
+    g_autoptr (GError) error = NULL;
+
+    g_return_if_fail (NULL != task);
+
+    manager = rstrnt_log_manager_get_instance ();
+    data = rstrnt_log_manager_get_task_data (manager, task, &error);
+
+    g_return_if_fail (NULL != data);
+
+    while (g_thread_pool_unprocessed (data->thread_pool) > 0 &&
+           g_thread_pool_get_num_threads (data->thread_pool) > 0)
+    {
+        g_usleep (G_USEC_PER_SEC / 4);
+    }
+
+    stream = G_OUTPUT_STREAM (data->task_log_data->output_stream);
+
+    if (!g_output_stream_flush (stream, cancellable, &error))
+    {
+        if (G_IO_ERROR_CANCELLED != error->code)
+        {
+            g_warning ("%s(): Failed to flush log stream: %s",
+                       __func__, error->message);
+        }
+    }
+
+    stream = G_OUTPUT_STREAM (data->harness_log_data->output_stream);
+
+    if (!g_output_stream_flush (stream, cancellable, &error))
+    {
+        if (G_IO_ERROR_CANCELLED != error->code)
+        {
+            g_warning ("%s(): Failed to flush log stream: %s",
+                       __func__, error->message);
+        }
+    }
+}
+
+static void
+rstrnt_upload_log (const RstrntTask    *task,
+                   RstrntServerAppData *app_data,
+                   SoupSession         *session,
+                   GCancellable        *cancellable,
+                   RstrntLogType        type)
+{
+    RstrntLogManager *manager;
+    g_autoptr (GError) error = NULL;
+    RstrntTaskLogData *data;
+    g_autofree char *path = NULL;
+    GMappedFile *file;
+    SoupURI *uri = NULL;
+    SoupMessage *message;
+    const char *contents;
+    size_t length;
+
+    manager = rstrnt_log_manager_get_instance ();
+    data = rstrnt_log_manager_get_task_data (manager, task, &error);
+
+    g_return_if_fail (NULL != data);
+
+    switch (type)
+    {
+        case RSTRNT_LOG_TYPE_TASK:
+        {
+            path = g_file_get_path (data->task_log_data->file);
+        }
+        break;
+
+        case RSTRNT_LOG_TYPE_HARNESS:
+        {
+            path = g_file_get_path (data->harness_log_data->file);
+        }
+        break;
+    }
+    file = g_mapped_file_new (path, false, &error);
+    if (NULL == file)
+    {
+        g_warning ("Task log file mapping failed: %s", error->message);
+
+        g_return_if_reached ();
+    }
+    switch (type)
+    {
+        case RSTRNT_LOG_TYPE_TASK:
+        {
+            uri = soup_uri_new_with_base (task->task_uri, LOG_PATH_TASK);
+        }
+        break;
+
+        case RSTRNT_LOG_TYPE_HARNESS:
+        {
+            uri = soup_uri_new_with_base (task->task_uri, LOG_PATH_HARNESS);
+        }
+        break;
+
+    }
+    message = soup_message_new_from_uri ("PUT", uri);
+    contents = g_mapped_file_get_contents (file);
+    length = g_mapped_file_get_length (file);
+
+    soup_message_headers_append (message->request_headers, "log-level", "2");
+    soup_message_set_request (message, "text/plain", SOUP_MEMORY_TEMPORARY,
+                              contents, length);
+
+    app_data->queue_message (session,
+                             message,
+                             NULL,
+                             rstrnt_on_log_uploaded,
+                             cancellable,
+                             file);
+
+    soup_uri_free (uri);
+}
+
+void
+rstrnt_upload_logs (const RstrntTask    *task,
+                    RstrntServerAppData *app_data,
+                    SoupSession         *session,
+                    GCancellable        *cancellable)
+{
+    g_autoptr (GTask) flush_task = NULL;
+
+    g_return_if_fail (NULL != task);
+    g_return_if_fail (NULL != app_data);
+    g_return_if_fail (SOUP_IS_SESSION (session));
+
+    rstrnt_flush_logs (task, cancellable);
+
+    rstrnt_upload_log (task, app_data, session, cancellable, RSTRNT_LOG_TYPE_TASK);
+    rstrnt_upload_log (task, app_data, session, cancellable, RSTRNT_LOG_TYPE_HARNESS);
+}
+
+static void
+rstrnt_log_manager_append_to_log (RstrntLogManager    *self,
+                                  const RstrntTask    *task,
+                                  RstrntLogType        type,
+                                  const char          *message,
+                                  size_t               message_length)
+{
+    g_autoptr (GError) error = NULL;
+    RstrntTaskLogData *data;
+    RstrntLogWriterData *writer_data;
+
+    data = rstrnt_log_manager_get_task_data (self, task, &error);
+    if (NULL == data)
+    {
+        g_return_if_reached ();
+    }
+    writer_data = g_new0 (RstrntLogWriterData, 1);
+
+    switch (type)
+    {
+        case RSTRNT_LOG_TYPE_TASK:
+            writer_data->log_data = data->task_log_data;
+
+            break;
+
+        case RSTRNT_LOG_TYPE_HARNESS:
+            writer_data->log_data = data->harness_log_data;
+
+            break;
+    }
+    writer_data->variant = g_variant_new_fixed_array (G_VARIANT_TYPE_BYTE,
+                                                      message, message_length,
+                                                      sizeof(*message));
+
+    (void) g_thread_pool_push (data->thread_pool, writer_data, NULL);
+}
+
+void
+rstrnt_log_bytes (const RstrntTask *task,
+                  RstrntLogType     type,
+                  const char       *message,
+                  size_t            message_length)
+{
+    RstrntLogManager *manager;
+
+    g_return_if_fail (NULL != task);
+    g_return_if_fail (NULL != message);
+
+    manager = rstrnt_log_manager_get_instance ();
+
+    rstrnt_log_manager_append_to_log (manager, task, type,
+                                      message, message_length);
+}
+
+void
+rstrnt_log (const RstrntTask *task,
+            RstrntLogType     type,
+            const char       *format,
+            ...)
+{
+    va_list args;
+    g_autofree char *message = NULL;
+    size_t message_length;
+    RstrntLogManager *manager;
+
+    g_return_if_fail (NULL != task);
+    g_return_if_fail (NULL != format);
+
+    va_start (args, format);
+
+    message = g_strdup_vprintf (format, args);
+
+    va_end (args);
+
+    message_length = strlen (message);
+    manager = rstrnt_log_manager_get_instance ();
+
+    rstrnt_log_manager_append_to_log (manager, task, type,
+                                      message, message_length);
+}
+
+static gpointer
+rstrnt_log_manager_create_instance (gpointer data)
+{
+    static RstrntLogManager *instance;
+
+    (void) data;
+
+    instance = g_object_new (RSTRNT_TYPE_LOG_MANAGER, NULL);
+
+    return instance;
+}
+
+RstrntLogManager *
+rstrnt_log_manager_get_instance (void)
+{
+    static GOnce once = G_ONCE_INIT;
+
+    g_once (&once, rstrnt_log_manager_create_instance, NULL);
+
+    return once.retval;
+}

--- a/src/logging.c
+++ b/src/logging.c
@@ -1,3 +1,20 @@
+/*
+  This file is part of Restraint.
+
+  Restraint is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Restraint is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Restraint.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 #include "logging.h"
 #include "task.h"
 

--- a/src/logging.h
+++ b/src/logging.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <gio/gio.h>
+#include <libsoup/soup.h>
+
+#include <stdbool.h>
+
+#define RSTRNT_TYPE_LOG_MANAGER rstrnt_log_manager_get_type ()
+
+G_DECLARE_FINAL_TYPE (RstrntLogManager, rstrnt_log_manager, RSTRNT, LOG_MANAGER, GObject)
+
+typedef enum
+{
+    RSTRNT_LOG_TYPE_TASK,
+    RSTRNT_LOG_TYPE_HARNESS,
+} RstrntLogType;
+
+typedef struct RstrntServerAppData RstrntServerAppData;
+typedef struct RstrntTask RstrntTask;
+
+
+void              rstrnt_upload_logs              (const RstrntTask    *task,
+                                                   RstrntServerAppData *app_data,
+                                                   SoupSession         *session,
+                                                   GCancellable        *cancellable);
+
+void              rstrnt_log_bytes                (const RstrntTask    *task,
+                                                   RstrntLogType        type,
+                                                   const char          *message,
+                                                   size_t               message_length);
+
+void              rstrnt_log                      (const RstrntTask    *task,
+                                                   RstrntLogType        type,
+                                                   const char          *format,
+                                                   ...) G_GNUC_PRINTF (3, 4);
+
+RstrntLogManager *rstrnt_log_manager_get_instance (void);

--- a/src/logging.h
+++ b/src/logging.h
@@ -1,4 +1,22 @@
-#pragma once
+/*
+  This file is part of Restraint.
+
+  Restraint is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Restraint is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Restraint.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _RESTRAINT_LOG_MANAGER_H
+#define _RESTRAINT_LOG_MANAGER_H
 
 #include <gio/gio.h>
 #include <libsoup/soup.h>
@@ -35,3 +53,5 @@ void              rstrnt_log                      (const RstrntTask    *task,
                                                    ...) G_GNUC_PRINTF (3, 4);
 
 RstrntLogManager *rstrnt_log_manager_get_instance (void);
+
+#endif

--- a/src/server.h
+++ b/src/server.h
@@ -31,7 +31,7 @@ typedef enum {
   ABORTED_TASK,
 } StateAborted;
 
-typedef struct {
+typedef struct RstrntServerAppData {
   RecipeSetupState state;
   guint port;
   guint recipe_handler_id;

--- a/src/server.h
+++ b/src/server.h
@@ -56,6 +56,6 @@ typedef struct RstrntServerAppData {
   guint last_signal;
 } AppData;
 
-void connections_write (AppData *app_data, const gchar *path,
-                        const gchar *msg_data, gsize msg_len);
+void restraint_log_task (AppData *app_data, RstrntLogType type, const char *data, gsize size);
+
 #endif

--- a/src/task.h
+++ b/src/task.h
@@ -1,4 +1,4 @@
-/*  
+/*
     This file is part of Restraint.
 
     Restraint is free software: you can redistribute it and/or modify
@@ -24,6 +24,7 @@
 #include <pty.h>
 #include <time.h>
 #include "recipe.h"
+#include "logging.h"
 #include "message.h"
 #include "server.h"
 #include "metadata.h"
@@ -65,7 +66,7 @@ typedef enum {
     TASK_FETCH_UNPACK,
 } TaskFetchMethod;
 
-typedef struct {
+typedef struct RstrntTask {
     /* Beaker ID for this task */
     gchar *task_id;
     /* Recipe attributes for this job */
@@ -129,7 +130,7 @@ typedef struct {
     TaskSetupState pass_state;
     TaskSetupState fail_state;
     gchar expire_time[80];
-    const gchar *logpath;
+    RstrntLogType log_type;
 } TaskRunData;
 
 Task *restraint_task_new(void);

--- a/src/test_logging.c
+++ b/src/test_logging.c
@@ -1,3 +1,20 @@
+/*
+  This file is part of Restraint.
+
+  Restraint is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Restraint is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Restraint.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 #include "logging.c"
 
 #include <glib.h>

--- a/src/test_logging.c
+++ b/src/test_logging.c
@@ -156,7 +156,7 @@ main (int    argc,
     g_autoptr (RstrntLogManager) log_manager = NULL;
     SoupServer *server;
     g_autoptr (GError) error = NULL;
-    g_autoptr (GSList) uris = NULL;
+    g_autoslist (SoupURI) uris = NULL;
     g_autofree gchar *task_id = NULL;
     RstrntTask task;
     int retval;

--- a/src/test_logging.c
+++ b/src/test_logging.c
@@ -15,9 +15,11 @@
   along with Restraint.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "logging.c"
-
 #include <glib.h>
+
+#define LOG_MANAGER_DIR "./test_logging_logs"
+
+#include "logging.c"
 
 static bool listening = true;
 
@@ -35,9 +37,7 @@ check_log_file_contents (const RstrntTask *task,
     char *file_contents;
     size_t contents_length;
 
-    path = g_build_path ("/",
-                         VAR_LIB_PATH, "logs", task->task_id,
-                         NULL);
+    path = g_build_path ("/", LOG_MANAGER_DIR, task->task_id, NULL);
     log_directory_file = g_file_new_for_path (path);
     child_file = g_file_get_child (log_directory_file, child);
     child_path = g_file_get_path (child_file);

--- a/src/test_logging.c
+++ b/src/test_logging.c
@@ -1,0 +1,174 @@
+#include "logging.c"
+
+#include <glib.h>
+
+static bool listening = true;
+
+static void
+check_log_file_contents (const RstrntTask *task,
+                         const char       *child,
+                         const char       *contents)
+{
+    g_autofree char *path = NULL;
+    g_autoptr (GFile) log_directory_file = NULL;
+    g_autoptr (GFile) child_file = NULL;
+    g_autofree char *child_path = NULL;
+    g_autoptr (GMappedFile) mapped_file = NULL;
+    size_t file_length;
+    char *file_contents;
+    size_t contents_length;
+
+    path = g_build_path ("/",
+                         VAR_LIB_PATH, "logs", task->task_id,
+                         NULL);
+    log_directory_file = g_file_new_for_path (path);
+    child_file = g_file_get_child (log_directory_file, child);
+    child_path = g_file_get_path (child_file);
+    mapped_file = g_mapped_file_new (child_path, FALSE, NULL);
+    file_length = g_mapped_file_get_length (mapped_file);
+    file_contents = g_mapped_file_get_contents (mapped_file);
+    contents_length = strlen (contents);
+
+    g_assert_cmpuint (contents_length, ==, file_length);
+    g_assert_cmpstr (contents, ==, file_contents);
+}
+
+static void
+test_rstrnt_log_write (gconstpointer user_data)
+{
+    const RstrntTask *task;
+    g_autofree char *task_contents = NULL;
+    g_autofree char *harness_contents = NULL;
+
+    task = user_data;
+    task_contents = g_strdup_printf ("el task");
+    harness_contents = g_strdup_printf ("el harness");
+
+    rstrnt_log (task, RSTRNT_LOG_TYPE_TASK, "%s", task_contents);
+    rstrnt_log (task, RSTRNT_LOG_TYPE_HARNESS, "%s", harness_contents);
+
+    rstrnt_flush_logs (task, NULL);
+
+    check_log_file_contents (task, "task.log", task_contents);
+    check_log_file_contents (task, "harness.log", harness_contents);
+}
+
+static void
+server_callback (SoupServer        *server,
+                 SoupMessage       *msg,
+                 const char        *path,
+                 GHashTable        *query,
+                 SoupClientContext *client,
+                 gpointer           user_data)
+{
+    static bool task_log_handled = false;
+    static bool harness_log_handled = false;
+
+    g_assert_cmpstr (msg->method, ==, SOUP_METHOD_PUT);
+
+    if (RSTRNT_LOG_TYPE_TASK == GPOINTER_TO_INT (user_data))
+    {
+        g_assert_false (task_log_handled);
+        task_log_handled = true;
+
+        soup_server_remove_handler (server, "/" LOG_PATH_TASK);
+    }
+    else if (RSTRNT_LOG_TYPE_HARNESS == GPOINTER_TO_INT (user_data))
+    {
+        g_assert_false (harness_log_handled);
+        harness_log_handled = true;
+
+        soup_server_remove_handler (server, "/" LOG_PATH_HARNESS);
+    }
+
+    if (task_log_handled && harness_log_handled)
+    {
+        listening = false;
+
+        soup_server_disconnect (server);
+    }
+
+    soup_message_set_status (msg, SOUP_STATUS_OK);
+}
+
+static void
+message_callback (SoupSession *session,
+                  SoupMessage *msg,
+                  gpointer     user_data)
+{
+    g_assert_cmpint (msg->status_code, ==, SOUP_STATUS_OK);
+}
+
+static void
+queue_message (SoupSession           *session,
+               SoupMessage           *msg,
+               gpointer               msg_data,
+               MessageFinishCallback  finish_callback,
+               GCancellable          *cancellable,
+               gpointer               user_data)
+{
+    soup_session_queue_message (session, msg, message_callback, NULL);
+}
+
+static void
+test_rstrnt_log_upload (gconstpointer user_data)
+{
+    const RstrntTask *task;
+    RstrntServerAppData app_data;
+    SoupSession *session;
+
+    task = user_data;
+    session = soup_session_new ();
+
+    app_data.queue_message = queue_message;
+
+    rstrnt_upload_logs (task, &app_data, session, NULL);
+
+    while (listening)
+    {
+        g_main_context_iteration (NULL, TRUE);
+    }
+
+    g_object_unref (session);
+}
+
+int
+main (int    argc,
+      char **argv)
+{
+    g_autoptr (RstrntLogManager) log_manager = NULL;
+    SoupServer *server;
+    g_autoptr (GError) error = NULL;
+    g_autoptr (GSList) uris = NULL;
+    RstrntTask task;
+    int retval;
+
+    g_test_init (&argc, &argv, NULL);
+
+    log_manager = rstrnt_log_manager_get_instance ();
+    server = soup_server_new (NULL, NULL);
+
+    soup_server_add_handler (server, "/" LOG_PATH_TASK, server_callback,
+                             GINT_TO_POINTER (RSTRNT_LOG_TYPE_TASK), NULL);
+    soup_server_add_handler (server, "/" LOG_PATH_HARNESS, server_callback,
+                             GINT_TO_POINTER (RSTRNT_LOG_TYPE_HARNESS), NULL);
+
+    g_test_add_data_func ("/logging/write", &task, test_rstrnt_log_write);
+    g_test_add_data_func ("/logging/upload", &task, test_rstrnt_log_upload);
+
+    if (!soup_server_listen_local (server, 43770, SOUP_SERVER_LISTEN_IPV4_ONLY, &error))
+    {
+        g_error ("%s", error->message);
+    }
+
+    uris = soup_server_get_uris (server);
+
+    task.task_id = "1997";
+    task.task_uri = uris->data;
+
+    retval = g_test_run ();
+
+    g_object_unref (server);
+
+    return retval;
+}

--- a/src/test_logging.c
+++ b/src/test_logging.c
@@ -157,6 +157,7 @@ main (int    argc,
     SoupServer *server;
     g_autoptr (GError) error = NULL;
     g_autoptr (GSList) uris = NULL;
+    g_autofree gchar *task_id = NULL;
     RstrntTask task;
     int retval;
 
@@ -179,8 +180,9 @@ main (int    argc,
     }
 
     uris = soup_server_get_uris (server);
+    task_id = g_strdup_printf ("%" G_GINT64_FORMAT, g_get_real_time ());
 
-    task.task_id = "1997";
+    task.task_id = task_id;
     task.task_uri = uris->data;
 
     retval = g_test_run ();


### PR DESCRIPTION
The log manager is used when restraintd runs under Beaker. Harness and taskout logs are cached by restraint until the task finishes. Logs are uploaded in chunks of 10MB, current maximum request size in the Beaker Lab Controller.

The log manager is not used when restraintd runs with the restraint client.

Closes #94 