### PR TITLE
Wait on Beaker's health status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 /third-party/tarballs
 /third-party/tree/
 /src/test-data/git-remote/
+/src/test_beaker_harness
 /src/test_cmd_abort
 /src/test_cmd_log
 /src/test_cmd_result

--- a/releasenotes/notes/beaker-health-check-e9991e4fe5ee94ea.yaml
+++ b/releasenotes/notes/beaker-health-check-e9991e4fe5ee94ea.yaml
@@ -1,0 +1,6 @@
+features:
+  - |
+    Wait on Beaker's health status
+    When Restraint runs under Beaker, Beaker's health status is checked
+    before performing steps that require communication with Beaker.
+    Recipe execution is held until Beaker is available.

--- a/src/Makefile
+++ b/src/Makefile
@@ -66,7 +66,7 @@ rstrnt-sync: cmd_sync.o
 restraint: client.o errors.o xml.o utils.o process.o restraint_forkpty.o
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
 
-restraintd: server.o recipe.o task.o fetch.o fetch_git.o fetch_uri.o param.o role.o metadata.o process.o message.o dependency.o utils.o config.o errors.o xml.o env.o restraint_forkpty.o
+restraintd: server.o recipe.o task.o fetch.o fetch_git.o fetch_uri.o param.o role.o metadata.o process.o message.o dependency.o utils.o config.o errors.o xml.o env.o restraint_forkpty.o beaker_harness.o
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 fetch_git.o: fetch.h fetch_git.h

--- a/src/Makefile
+++ b/src/Makefile
@@ -88,9 +88,10 @@ config.o: config.h
 errors.o: errors.h
 xml.o: xml.h
 restraint_forkpty.o:
+beaker_harness.o:
 
 # Tests
-
+TEST_PROGRAMS += test_beaker_harness
 TEST_PROGRAMS += test_cmd_abort
 TEST_PROGRAMS += test_cmd_log
 TEST_PROGRAMS += test_cmd_result
@@ -108,6 +109,14 @@ TEST_PROGRAMS += test_utils
 
 test_%: test_%.o
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
+
+MOCKS_BEAKER_HARNESS = -Wl,--wrap=soup_session_send_message
+
+test_beaker_harness: test_beaker_harness.o beaker_harness.o
+	$(CC) $(MOCKS_BEAKER_HARNESS) $(LDFLAGS) -o $@ $^ $(LIBS)
+
+test_beaker_harness.o: test_beaker_harness.c
+	$(CC) $(MOCKS_BEAKER_HARNESS) $(CFLAGS) -c -o $@ $^ $(LIBS)
 
 test_fetch_git: fetch.o fetch_git.o errors.o
 test_fetch_git.o: fetch_git.h

--- a/src/beaker_harness.c
+++ b/src/beaker_harness.c
@@ -1,0 +1,83 @@
+/*
+    This file is part of Restraint.
+
+    Restraint is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Restraint is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Restraint.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdlib.h>
+#include <string.h>
+#include <glib.h>
+#include <libsoup/soup.h>
+
+#include "beaker_harness.h"
+
+#define BKR_ENV_FILE "/etc/profile.d/beaker-harness-env.sh"
+
+#define STREMPTY(str) (str == NULL || strlen (str) == 0)
+
+/*
+ * Checks if Beaker environment exists
+ *
+ * Note that there is no guarantee that the environment is valid or
+ * belongs to the current instance.
+ *
+ * Returns non-zero if Beaker environment exists, 0 otherwise.
+ */
+int
+rstrnt_bkr_env_exists (void)
+{
+    return (int) g_file_test (BKR_ENV_FILE, G_FILE_TEST_EXISTS);
+}
+
+/*
+ * Checks if recipe_url is reachable and points to a valid recipe
+ * endpoint.
+ *
+ * Note that this is not checking the recipe's actual content.
+ *
+ * Returns BKR_HEALTH_STATUS_GOOD if the response passed the health
+ * criteria, BKR_HEALTH_STATUS_BAD if the response didn't pass the
+ * health criteria, or BKR_HEALTH_STATUS_UNKNOWN if no response was
+ * received.
+ */
+bkr_health_status_t
+rstrnt_bkr_check_recipe (const char *recipe_url)
+{
+    SoupStatus              status;
+    g_autoptr (SoupMessage) msg = NULL;
+    g_autoptr (SoupSession) session = NULL;
+
+    g_return_val_if_fail (!STREMPTY (recipe_url), BKR_HEALTH_STATUS_UNKNOWN);
+
+    msg = soup_message_new ("HEAD", recipe_url);
+
+    /* msg will be NULL if the URL cannot be parsed */
+    g_return_val_if_fail (msg != NULL, BKR_HEALTH_STATUS_UNKNOWN);
+
+    session = soup_session_new_with_options ("user-agent", "restraint",
+                                             "ssl-strict", FALSE,
+                                             NULL);
+
+    status = soup_session_send_message (session, msg);
+
+    if (SOUP_STATUS_IS_SUCCESSFUL (status)
+        && soup_message_headers_header_equals (msg->response_headers, "Content-Type", "application/xml")
+        && soup_message_headers_get_content_length (msg->response_headers) > 0)
+        return BKR_HEALTH_STATUS_GOOD;
+
+    if (status == SOUP_STATUS_NONE || SOUP_STATUS_IS_TRANSPORT_ERROR (status))
+        return BKR_HEALTH_STATUS_UNKNOWN;
+
+    return BKR_HEALTH_STATUS_BAD;
+}

--- a/src/beaker_harness.h
+++ b/src/beaker_harness.h
@@ -1,0 +1,34 @@
+/*
+    This file is part of Restraint.
+
+    Restraint is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Restraint is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Restraint.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _RESTRAINT_BEAKER_HARNESS_H
+#define _RESTRAINT_BEAKER_HARNESS_H
+
+#define BKR_ENV_EXISTS()           (rstrnt_bkr_env_exists () != 0)
+#define BKR_RECIPE_IS_HEALTHY(url) (BKR_HEALTH_STATUS_GOOD == rstrnt_bkr_check_recipe (url))
+
+typedef enum bkr_health_status {
+    BKR_HEALTH_STATUS_UNKNOWN, /* No response from lab controller */
+    BKR_HEALTH_STATUS_GOOD,    /* Expected response from lab controller */
+    BKR_HEALTH_STATUS_BAD,     /* Un-expected response from lab controller */
+} bkr_health_status_t;
+
+bkr_health_status_t rstrnt_bkr_check_recipe (const char *recipe_url);
+
+int rstrnt_bkr_env_exists (void);
+
+#endif

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -1,4 +1,4 @@
-/*  
+/*
     This file is part of Restraint.
 
     Restraint is free software: you can redistribute it and/or modify
@@ -69,4 +69,6 @@ void restraint_recipe_parse_stream (GInputStream *stream, gpointer user_data);
 void restraint_recipe_update_roles(Recipe *recipe, xmlDoc *doc, GError **error);
 void restraint_recipe_free(Recipe *recipe);
 void recipe_handler_finish (gpointer user_data);
+gboolean recipe_wait_on_beaker (const gchar *recipe_url, const gchar *state_tag);
+
 #endif

--- a/src/test_beaker_harness.c
+++ b/src/test_beaker_harness.c
@@ -1,0 +1,89 @@
+#include <stdlib.h>
+#include <glib.h>
+#include <libsoup/soup.h>
+
+#include "beaker_harness.h"
+
+int mocked_soup_status = -1;
+
+guint __real_soup_session_send_message (SoupSession *session, SoupMessage *msg);
+
+guint
+__wrap_soup_session_send_message (SoupSession *session,
+                                  SoupMessage *msg)
+{
+    if (mocked_soup_status < 0)
+        return __real_soup_session_send_message (session, msg);
+
+    soup_message_set_status (msg, mocked_soup_status);
+
+    if (mocked_soup_status == SOUP_STATUS_OK) {
+        soup_message_headers_append (msg->response_headers, "Content-Type", "application/xml");
+        soup_message_headers_set_content_length (msg->response_headers, 42);
+    }
+
+    return mocked_soup_status;
+}
+
+static void
+test_rstrnt_bkr_check_recipe_no_lc (gconstpointer test_data)
+{
+    const char *recipe_url;
+
+    recipe_url = (char *) test_data;
+
+    mocked_soup_status = -1;
+
+    g_assert_cmpint (BKR_HEALTH_STATUS_UNKNOWN, ==, rstrnt_bkr_check_recipe (recipe_url));
+}
+
+static void
+test_rstrnt_bkr_check_recipe_good (gconstpointer test_data)
+{
+    bkr_health_status_t status;
+    const char *recipe_url;
+
+    recipe_url = (char *) test_data;
+
+    mocked_soup_status = SOUP_STATUS_OK;
+
+    status = rstrnt_bkr_check_recipe (recipe_url);
+
+    mocked_soup_status = -1;
+
+    g_assert_cmpint (BKR_HEALTH_STATUS_GOOD, ==, status);
+}
+
+static void
+test_rstrnt_bkr_check_recipe_bad (gconstpointer test_data)
+{
+    bkr_health_status_t status;
+    const char *recipe_url;
+
+    recipe_url = (char *) test_data;
+
+    mocked_soup_status = SOUP_STATUS_NOT_FOUND;
+
+    status = rstrnt_bkr_check_recipe (recipe_url);
+
+    mocked_soup_status = -1;
+
+    g_assert_cmpint (BKR_HEALTH_STATUS_BAD, ==, status);
+}
+
+int
+main (int   argc,
+      char *argv[])
+{
+    const char * recipe_url;
+
+    recipe_url = "http://nohost:4242/recipes/1/";
+
+    g_test_init (&argc, &argv, NULL);
+
+    g_test_add_data_func ("/beaker/harness/health/bad", recipe_url, test_rstrnt_bkr_check_recipe_bad);
+    g_test_add_data_func ("/beaker/harness/health/good", recipe_url, test_rstrnt_bkr_check_recipe_good);
+    g_test_add_data_func ("/beaker/harness/health/no_lc", recipe_url, test_rstrnt_bkr_check_recipe_no_lc);
+
+    return g_test_run ();
+}


### PR DESCRIPTION
When Restraint runs under Beaker, check Beaker's health status and wait until it is good before performing,
- Recipe fetching
- Task role refreshing
- Task fetching
- Dependency install

The wait is done in the recipe handler, for recipe fetching, and the task handler for the other operations.
If health status is not good, restraint will wait 60 seconds before trying again.

The health status is taken from the recipe endpoint in the lab controller. This will give some guarantees that both, lab controller and Beaker server are in good condition.

This doesn't affect client/server operation.

Add Beaker harness lib with,
- Recipe endpoint health check
- Environment check

Closes #124 