### PR TITLE
Make restraint less OS specific

### DIFF
--- a/legacy/bin/rhts-run-simple-test
+++ b/legacy/bin/rhts-run-simple-test
@@ -30,7 +30,7 @@
 #
 # Tests using this should have a runtest.sh that reads:
 #
-#  #!/bin/sh
+#  #!/bin/bash
 #  rhts-run-simple-test [-u user-to-run-as] name-of-test name-of-my-executable
 # you can have multiple lines for multiple tests...
 

--- a/plugins/task_run.d/20_unconfined
+++ b/plugins/task_run.d/20_unconfined
@@ -59,7 +59,7 @@ function runcon_unconfined() {
   fi
 }
 
-if selinuxenabled; then
+if command -v selinuxenabled >/dev/null && selinuxenabled; then
   if [ 4 -le 0$RSTRNT_DEBUG ]; then
       rstrnt_info "selinux enabled: trying to switch context..."
   fi


### PR DESCRIPTION
Use /bin/bash instead of /bin/sh as in some OSes /bin/sh is the Dash
shell and not the bash shell.

Also check if we have the selinuxenabled command before running it.