### PR TITLE
containers: Add ability to build statically linked rpms

### DIFF
--- a/containers/utils/build-rpms.sh
+++ b/containers/utils/build-rpms.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 
+set -e
+
 RESTRAINT_DIR=/restraint
 RPMBUILD_DIR="$RESTRAINT_DIR"/tito-test-build
+BUILD_OPTS="--without static"
 
-cd $RESTRAINT_DIR || exit
+cd $RESTRAINT_DIR
 
-dnf -y install tito || exit
+dnf -y install tito
 
-tito build --rpmbuild-options="--without static" --test --rpm -o "$RPMBUILD_DIR"
+if [ "$1" == "static" ] ; then
+	BUILD_OPTS=""
+	dnf install -y $(rpmspec --buildrequires -q restraint.spec)
+fi
+
+tito build --rpmbuild-options="$BUILD_OPTS" --test --rpm -o "$RPMBUILD_DIR"


### PR DESCRIPTION
By default, rpms are built with dynamic linking, saves time.

To build statically linked,
```
 $ ./containers/run.sh ./containers/utils/build-rpms.sh static
```