### PR TITLE
fetch_uri: Use memfd for writing

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -30,7 +30,7 @@ ifneq ($(DEVEL), 1)
     CFLAGS += -O2
 endif
 
-CFLAGS += -Wall -Werror -std=c99 $(shell pkg-config --cflags $(PACKAGES))
+CFLAGS += -D_GNU_SOURCE -Wall -std=c99 $(shell pkg-config --cflags $(PACKAGES))
 
 ifeq ($(STATIC), 1)
     # The right thing to do here is `pkg-config --libs --static`, which would


### PR DESCRIPTION
Currently, the code uses a GMemoryInputStream for reading the compressed
data that is fetched using libcurl, which does not have seeking
semantics, identical to those of lseek() (i.e. reading past the end
results in a hard error). Seeking is needed to make libarchive use the
seeking decompressor for ZIP archives, because that is the only way it
will read the central directory and get the correct file attributes.

This commit replaces the memory stream with a memfd for reading and a
memfd-backed GUnixOutputStream for writing.

https://github.com/libarchive/libarchive/issues/1106

Fixes https://github.com/beaker-project/restraint/issues/136

Change-Id: Ifdf2e2aef448c9140d9330d6b9a4a754c519df5d