### PR TITLE
Use fedora-registry for Fedora container images

### DIFF
--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -13,7 +13,7 @@ jobs:
         container: ["fedora:31", "fedora:32"]
     runs-on: ubuntu-latest
     container:
-      image: ${{ matrix.container }}
+      image: registry.fedoraproject.org/${{ matrix.container }}
 
     steps:
     - uses: actions/checkout@v1
@@ -40,7 +40,7 @@ jobs:
         container: ["fedora:31", "fedora:32"]
     runs-on: ubuntu-latest
     container:
-      image: ${{ matrix.container }}
+      image: registry.fedoraproject.org/${{ matrix.container }}
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/review-checks.yml
+++ b/.github/workflows/review-checks.yml
@@ -10,7 +10,7 @@ jobs:
         container: ["fedora:31", "fedora:32", "fedora:rawhide"]
     runs-on: ubuntu-latest
     container:
-      image: ${{ matrix.container }}
+      image: registry.fedoraproject.org/${{ matrix.container }}
 
     steps:
     - uses: actions/checkout@v1
@@ -37,7 +37,7 @@ jobs:
         container: ["fedora:31", "fedora:32", "fedora:rawhide"]
     runs-on: ubuntu-latest
     container:
-      image: ${{ matrix.container }}
+      image: registry.fedoraproject.org/${{ matrix.container }}
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Explicitly define registry which we would like to use for container images.
In this case we should rely on Fedora source.

Signed-off-by: Martin Styk <mastyk@redhat.com>