### PR TITLE
Bump libsoup to 2.62.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,8 @@
 /third-party/libarchive-3.4.0/
 /third-party/libffi-3.1.tar.gz
 /third-party/libffi-3.1/
-/third-party/libsoup-2.52.2.tar.xz
-/third-party/libsoup-2.52.2/
+/third-party/libsoup-2.62.3.tar.xz
+/third-party/libsoup-2.62.3/
 /third-party/libxml2-2.9.10.tar.gz
 /third-party/libxml2-2.9.10/
 /third-party/xz-5.2.4.tar.gz

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -60,7 +60,7 @@ versions are listed):
  - libxml2-2.9.10
  - libarchive-3.4.0
  - xz-5.2.4
- - libsoup-2.52.2
+ - libsoup-2.62.3
  - intltool-0.51.0
  - selinux-2.7
  - curl-7.68.0

--- a/restraint.spec
+++ b/restraint.spec
@@ -31,7 +31,7 @@ Source107:      libarchive-3.4.0.tar.gz
 Source108:      xz-5.2.4.tar.gz
 Source109:      sqlite-autoconf-3310100.tar.gz
 Source110:      intltool-0.51.0.tar.gz
-Source111:      libsoup-2.52.2.tar.xz
+Source111:      libsoup-2.62.3.tar.xz
 Source112:      json-c-0.13.1.tar.gz
 Source114:      openssl-1.0.1m.tar.gz
 Source115:      autoconf-2.69.tar.gz

--- a/third-party/Makefile
+++ b/third-party/Makefile
@@ -7,7 +7,7 @@ LIBXML2 = libxml2-2.9.10
 CURL = curl-7.68.0
 LIBARCHIVE = libarchive-3.4.0
 XZ = xz-5.2.4
-LIBSOUP = libsoup-2.52.2
+LIBSOUP = libsoup-2.62.3
 OPENSSL = openssl-1.0.1m
 SQLITE = sqlite-autoconf-3310100
 INTLTOOL = intltool-0.51.0
@@ -198,7 +198,7 @@ $(INTLTOOL).tar.gz:
 
 TAR_BALLS += $(LIBSOUP).tar.xz
 $(LIBSOUP).tar.xz:
-	curl -f -L -O http://ftp.gnome.org/pub/GNOME/sources/libsoup/2.52/$@
+	curl -f -L -O http://ftp.gnome.org/pub/GNOME/sources/libsoup/2.62/$@
 
 TAR_BALLS += $(AUTOCONF).tar.gz
 $(AUTOCONF).tar.gz:


### PR DESCRIPTION
Note that the last libsoup version supporting autotools is 2.65.1, but 2.63.1 added a dependency with libpsl 0.20.