### PR TITLE
Add test cases for parse_task_config

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -134,7 +134,10 @@ test_dependency.o: dependency.h errors.h process.h param.h
 
 test_env: test_env.o errors.o env.o utils.o cmd_utils.o
 
-test_task: task.o recipe.o xml.o utils.o config.o beaker_harness.o param.o role.o errors.o metadata.o fetch.o fetch_uri.o fetch_git.o process.o restraint_forkpty.o env.o dependency.o
+# Note that test_task.c includes task.c, therefore there is no need to
+# link task.o
+test_task: recipe.o xml.o utils.o config.o beaker_harness.o param.o role.o errors.o metadata.o fetch.o fetch_uri.o fetch_git.o process.o restraint_forkpty.o env.o dependency.o
+test_task.o: test_task.c task.c
 
 test_recipe: recipe.o task.o fetch_git.o param.o role.o metadata.o
 test_recipe.o: recipe.h task.h param.h

--- a/src/task.c
+++ b/src/task.c
@@ -840,8 +840,10 @@ restraint_next_task (AppData *app_data, TaskSetupState task_state) {
     return FALSE;
 }
 
-gboolean
-parse_task_config (gchar *config_file, Task *task, GError **error)
+static gboolean
+parse_task_config (gchar   *config_file,
+                   Task    *task,
+                   GError **error)
 {
     GError *tmp_error = NULL;
 

--- a/src/test-data/bad.conf
+++ b/src/test-data/bad.conf
@@ -1,0 +1,2 @@
+[42]
+localwatchdog=10

--- a/src/test-data/task42.conf
+++ b/src/test-data/task42.conf
@@ -1,0 +1,8 @@
+[42]
+reboots=1
+localwatchdog=true
+started=true
+
+[offsets_42]
+logs/taskout.log=42
+logs/harness.log=58

--- a/src/test_task.c
+++ b/src/test_task.c
@@ -15,10 +15,9 @@
     along with Restraint.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #include <glib.h>
 
-#include "task.h"
+#include "task.c"
 
 SoupSession *soup_session;
 


### PR DESCRIPTION
Include task source in tests to be able to test private definitions.

Make `parse_task_config` private, as it's not used outside the task module and it was not declared in the header file.

Add test cases for parse_task_config:
- Config file doesn't exist
- Config file exists with values
- Config file exists with bad value