### PR TITLE
Refactor task config handling

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -840,6 +840,32 @@ restraint_next_task (AppData *app_data, TaskSetupState task_state) {
     return FALSE;
 }
 
+gboolean
+task_config_set_offset (const gchar  *config_file,
+                        Task         *task,
+                        const gchar  *path,
+                        goffset       value,
+                        GError      **error)
+{
+    GError           *tmp_err = NULL;
+    g_autofree gchar *section = NULL;
+
+    g_return_val_if_fail (task != NULL, FALSE);
+    g_return_val_if_fail (config_file != NULL, FALSE);
+    g_return_val_if_fail (path != NULL, FALSE);
+
+    section = g_strdup_printf ("offsets_%s", task->task_id);
+
+    restraint_config_set ((gchar *) config_file, section, path, &tmp_err, G_TYPE_UINT64, value);
+
+    if (NULL == tmp_err)
+        return TRUE;
+
+    g_propagate_error (error, tmp_err);
+
+    return FALSE;
+}
+
 static goffset *
 restraint_task_new_offset (GHashTable  *offsets,
                            const gchar *path,
@@ -1253,8 +1279,7 @@ connections_write (AppData     *app_data,
                              app_data->cancellable,
                              NULL);
 
-    section = g_strdup_printf ("offsets_%s", task->task_id);
-    restraint_config_set (app_data->config_file, section, path, NULL, G_TYPE_UINT64, *offset);
+    (void) task_config_set_offset (app_data->config_file, task, path, *offset, NULL);
 }
 
 void

--- a/src/task.h
+++ b/src/task.h
@@ -142,6 +142,7 @@ gboolean restraint_build_env(Task *task, GError **error);
 void restraint_task_status (Task *task, AppData *app_data, gchar *, gchar *, GError *reason);
 void restraint_task_run(Task *task);
 void restraint_task_free(Task *task);
+goffset *restraint_task_get_offset (Task *task, const gchar *path);
 void restraint_init_result_hash (AppData *app_data);
 gboolean task_io_callback (GIOChannel *io, GIOCondition condition, gpointer user_data);
 void task_handler_callback (gint pid_result, gboolean localwatchdog, gpointer user_data, GError *error);

--- a/src/task.h
+++ b/src/task.h
@@ -148,6 +148,8 @@ gboolean task_io_callback (GIOChannel *io, GIOCondition condition, gpointer user
 void task_handler_callback (gint pid_result, gboolean localwatchdog, gpointer user_data, GError *error);
 gboolean idle_task_setup (gpointer user_data);
 
+gboolean task_config_set_offset (const gchar *config_file, Task *task, const gchar *path, goffset value, GError **error);
+
 void restraint_log_task (AppData *app_data, RstrntLogType type, const char *data, gsize size);
 
 extern SoupSession *soup_session;

--- a/src/test_task.c
+++ b/src/test_task.c
@@ -134,6 +134,28 @@ test_restraint_task_free (void)
     restraint_task_free (task);
 }
 
+static void
+test_restraint_task_get_offset (void)
+{
+    Task        *task;
+    const gchar *path;
+    goffset     *offset;
+
+    path = "/some/random/path.log";
+
+    task = restraint_task_new ();
+
+    g_assert_nonnull (task);
+
+    offset = restraint_task_get_offset (task, path);
+
+    assert_offset (task->offsets, path, 0);
+
+    g_assert_true (offset == restraint_task_get_offset (task, path));
+
+    restraint_task_free (task);
+}
+
 int
 main (int   argc,
       char *argv[])
@@ -145,6 +167,7 @@ main (int   argc,
     g_test_add_func ("/task/parse_task_config/no_file", test_parse_task_config_no_file);
     g_test_add_func ("/task/parse_task_config/file_exists", test_parse_task_config_file_exists);
     g_test_add_func ("/task/parse_task_config/bad_file", test_parse_task_config_bad_file);
+    g_test_add_func ("/task/restraint_task_get_offset", test_restraint_task_get_offset);
 
     return g_test_run ();
 }


### PR DESCRIPTION
The intent is to be able to use `restraint_task_get_offset` and `task_config_set_offset` in the log manager.