### PR TITLE
test: Add Fedora 33 container provision script

### DIFF
--- a/containers/provision/fedora:33.sh
+++ b/containers/provision/fedora:33.sh
@@ -1,0 +1,1 @@
+fedora:latest.sh


### PR DESCRIPTION
Now that Fedora 33 has branched, Add a container
provision script for it.