### PR TITLE
Upload logs incrementally on time intervals

### DIFF
--- a/releasenotes/notes/incremental-log-manager-0e7bfc306f58570f.yaml
+++ b/releasenotes/notes/incremental-log-manager-0e7bfc306f58570f.yaml
@@ -1,0 +1,11 @@
+features:
+  - |
+    Enable log manager for log caching
+
+fixes:
+  - |
+    Upload cached logs in time intervals
+    The log manager uploads the cached contents of taskout.log and
+    harness.log every 15 seconds. This allows to follow task progress
+    and avoids missing logs when the external watchdog aborts the
+    recipe.

--- a/src/Makefile
+++ b/src/Makefile
@@ -161,7 +161,7 @@ test_cmd_utils: test_cmd_utils.o cmd_utils.o env.o utils.o errors.o
 
 test_utils: test_utils.o utils.o errors.o
 
-test_logging: test_logging.o message.o
+test_logging: test_logging.o message.o task.o recipe.o xml.o utils.o config.o beaker_harness.o param.o role.o errors.o metadata.o fetch.o fetch_uri.o fetch_git.o process.o restraint_forkpty.o env.o dependency.o
 test_logging.o: test_logging.c logging.c
 
 test-data/git-remote: test-data/git-remote.tgz

--- a/src/logging.c
+++ b/src/logging.c
@@ -603,3 +603,11 @@ rstrnt_log_manager_get_instance (void)
 
     return once.retval;
 }
+
+gboolean
+rstrnt_log_manager_enabled (RstrntServerAppData *app_data)
+{
+    g_assert (NULL != app_data);
+
+    return !app_data->stdin && app_data->uploader_interval > 0;
+}

--- a/src/logging.c
+++ b/src/logging.c
@@ -417,6 +417,8 @@ rstrnt_upload_log (const RstrntTask    *task,
 
     g_return_if_fail (NULL != data);
 
+    g_clear_error (&error);
+
     log_path = rstrnt_log_type_get_path (type);
     log_data = rstrnt_task_log_get_data (data, type);
 

--- a/src/logging.h
+++ b/src/logging.h
@@ -23,8 +23,6 @@
 
 #include <stdbool.h>
 
-#define LOG_MANAGER_ENABLED 0
-
 #define RSTRNT_TYPE_LOG_MANAGER rstrnt_log_manager_get_type ()
 
 G_DECLARE_FINAL_TYPE (RstrntLogManager, rstrnt_log_manager, RSTRNT, LOG_MANAGER, GObject)
@@ -56,6 +54,8 @@ void              rstrnt_log                      (const RstrntTask    *task,
 
 RstrntLogManager *rstrnt_log_manager_get_instance (void);
 
-const gchar *     rstrnt_log_type_get_path        (RstrntLogType type);
+const gchar      *rstrnt_log_type_get_path        (RstrntLogType type);
+
+gboolean          rstrnt_log_manager_enabled      (RstrntServerAppData *app_data);
 
 #endif

--- a/src/server.c
+++ b/src/server.c
@@ -620,14 +620,18 @@ rstrnt_listen_any_local (SoupServer *server, guint port)
 }
 
 int main(int argc, char *argv[]) {
-  AppData *app_data = g_slice_new0(AppData);
-  app_data->cancellable = g_cancellable_new ();
-  app_data->aborted = ABORTED_NONE;
-  app_data->config_file = NULL;
+  AppData *app_data;
   const gchar *config = "config.conf";
   SoupServer *soup_server = NULL;
   GError *error = NULL;
+
+  app_data = g_slice_new0 (AppData);
+  app_data->cancellable = g_cancellable_new ();
+  app_data->aborted = ABORTED_NONE;
+  app_data->config_file = NULL;
   app_data->port = 0;
+  app_data->uploader_source_id = 0;
+  app_data->uploader_interval = LOG_UPLOAD_INTERVAL;
 
   GOptionEntry entries [] = {
     { "port", 'p', 0, G_OPTION_ARG_INT, &app_data->port, "Port to listen on", "PORT" },
@@ -728,7 +732,7 @@ int main(int argc, char *argv[]) {
 
   g_main_loop_unref(loop);
 
-  if (LOG_MANAGER_ENABLED && !app_data->stdin) {
+  if (rstrnt_log_manager_enabled (app_data)) {
       RstrntLogManager *log_manager;
 
       log_manager = rstrnt_log_manager_get_instance ();

--- a/src/server.h
+++ b/src/server.h
@@ -26,6 +26,8 @@
 #define PLUGIN_DIR "/usr/share/restraint/plugins"
 
 #define LOG_UPLOAD_INTERVAL 15  /* Seconds */
+#define LOG_UPLOAD_MIN_INTERVAL 3  /* Seconds */
+#define LOG_UPLOAD_MAX_INTERVAL 60  /* Seconds */
 
 typedef enum {
   ABORTED_NONE,

--- a/src/server.h
+++ b/src/server.h
@@ -25,6 +25,8 @@
 #define TASK_PLUGIN_SCRIPT "/usr/share/restraint/plugins/run_task_plugins"
 #define PLUGIN_DIR "/usr/share/restraint/plugins"
 
+#define LOG_UPLOAD_INTERVAL 15  /* Seconds */
+
 typedef enum {
   ABORTED_NONE,
   ABORTED_RECIPE,
@@ -54,6 +56,8 @@ typedef struct RstrntServerAppData {
   guint fetch_retries;
   gboolean stdin;
   guint last_signal;
+  guint uploader_source_id; /* Event source ID for log uploader */
+  guint uploader_interval; /* In seconds. 0 disables the log manager */
 } AppData;
 
 #endif

--- a/src/test_logging.c
+++ b/src/test_logging.c
@@ -299,6 +299,32 @@ test_rstrnt_chunk_log_nonzero_offset (void)
     g_object_unref (msgv[0]);
 }
 
+static void
+test_rstrnt_log_manager_enabled (void)
+{
+    AppData app_data;
+
+    app_data.stdin = FALSE;
+    app_data.uploader_interval = 0;
+
+    g_assert_false (rstrnt_log_manager_enabled (&app_data));
+
+    app_data.stdin = FALSE;
+    app_data.uploader_interval = 15;
+
+    g_assert_true (rstrnt_log_manager_enabled (&app_data));
+
+    app_data.stdin = TRUE;
+    app_data.uploader_interval = 0;
+
+    g_assert_false (rstrnt_log_manager_enabled (&app_data));
+
+    app_data.stdin = TRUE;
+    app_data.uploader_interval = 10;
+
+    g_assert_false (rstrnt_log_manager_enabled (&app_data));
+}
+
 int
 main (int    argc,
       char **argv)
@@ -328,6 +354,7 @@ main (int    argc,
     g_test_add_func ("/logging/upload/no_logs", test_rstrnt_log_upload_no_logs);
     g_test_add_func ("/logging/chunking/zero_offset", test_rstrnt_chunk_log_zero_offset);
     g_test_add_func ("/logging/chunking/nonzero_offset", test_rstrnt_chunk_log_nonzero_offset);
+    g_test_add_func ("/logging/enabled", test_rstrnt_log_manager_enabled);
 
     if (!soup_server_listen_local (server, 43770, SOUP_SERVER_LISTEN_IPV4_ONLY, &error))
     {


### PR DESCRIPTION
Previously, logs were uploaded only after the task completed. This behaviour introduced two issues,
- The task progress cannot be checked through Beaker
- The logs are not uploaded to Beaker if the recipe is cancelled by the user or aborted by the external watchdog

The purpose of the log manager is to reduce the amount of communication between Restraint and the Beaker Lab Controller, to reduce load on the Lab Controller itself and also on the network. Without the log manager, a "noisy" task can produce somewhere between 50 and 100 messages per second.

A solution to the issues introduced that allows to reduce the amount of communication with the Lab Controller is to keep caching the logs in the test machine and upload them progressively.

Incremental uploads on time intervals is implemented by setting an event source that calls the log manager upload function every 15 seconds. This value should allow users to quickly check the task progress with a good amount of caching.

In the log manager's upload function, incremental uploads were implemented using offsets as with the previous communication method.

For debugging purposes only, the upload interval can be set through the configuration file `/var/lib/restraint/log_manager.conf`,
```
[log-manager]
upload_interval=10
```
Setting `upload_interval=0` disables the log manager. Current valid values are between 3 and 60, both included. A value outside this range will be overridden with the closest valid value in the range.

Closes #152 