### PR TITLE
fix: Move logs under /var/tmp

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -19,8 +19,10 @@
 #include "task.h"
 #include "beaker_harness.h"
 
+/* FIX: Use /var/lib/restraint/logs instead. Needs SELinux policy
+   updates. */
 #ifndef LOG_MANAGER_DIR
-#define LOG_MANAGER_DIR VAR_LIB_PATH "/logs"
+#define LOG_MANAGER_DIR "/var/tmp/restraintd/logs"
 #endif
 
 struct _RstrntLogManager


### PR DESCRIPTION
This is a temporary workaround before proper SELinux policies for `/var/lib/restraint` are defined.