### PR TITLE
Debian containers

### DIFF
--- a/containers/provision/debian:latest.sh
+++ b/containers/provision/debian:latest.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+DEPS_TOOL="apt-get -o Debug::pkgProblemResolver=yes -y --no-install-recommends"
+
+apt -y update
+
+apt -y install --no-install-recommends build-essential \
+				       devscripts \
+				       equivs \
+				       python3-six \
+				       python3-flask \
+				       python3-pytest \
+				       git-daemon-run \
+				       valgrind
+
+mk-build-deps --install --remove --tool "$DEPS_TOOL" /restraint/debian/control

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Beaker Project <maintainer@beaker-project.org>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 9), curl, gcc, gettext, libarchive-dev, libcurl4, libcurl4-gnutls-dev, libglib2.0-dev, libselinux1-dev, libsoup2.4-dev, libssh-dev, libxml-sax-expat-perl, libxml2-dev
+Build-Depends: debhelper (>= 9), curl, gcc, gettext, libarchive-dev, libcurl4, libcurl4-gnutls-dev, libglib2.0-dev, libselinux1-dev, libsoup2.4-dev, libssh-dev, libxml-sax-expat-perl, libxml2-dev, libjson-c-dev
 
 Package: restraint
 Architecture: any

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -40,7 +40,7 @@ cleanup()
 }
 trap cleanup EXIT
 
-if [[ -f /usr/libexec/git-core/git-daemon ]] ; then
+if [[ -f /usr/libexec/git-core/git-daemon ]] || [[ -f /usr/lib/git-core/git-daemon ]]; then
     git daemon --reuseaddr --listen=127.0.0.1 \
         --base-path=test-data/git-remote --export-all --enable=upload-archive \
         --verbose --detach --pid-file=${GITD_PID_FILE}


### PR DESCRIPTION
Add some love for Debian through containers support for,

```
$ ./containers/run.sh -i debian:latest make clean all check valgrind
```
The script `debian/build-deb-package.sh` can be used,

```
$ ./containers/run.sh -i debian:latest ./debian/build-deb-package.sh`
```

Although needs some adjustments and clean up to get something similar as `containers/utils/build-rpms.sh`, perhaps `containers/utils/build-debs.sh`.