### PR TITLE
Refactor config

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -29,6 +29,22 @@
 #include "errors.h"
 #include "config.h"
 
+static GKeyFile *
+restraint_config_read_key_file (const gchar  *file,
+                                GError      **err)
+{
+    GKeyFile *key_file;
+    GKeyFileFlags flags;
+
+    key_file = g_key_file_new ();
+
+    flags = G_KEY_FILE_KEEP_COMMENTS | G_KEY_FILE_KEEP_TRANSLATIONS;
+
+    g_key_file_load_from_file (key_file, file, flags, err);
+
+    return key_file;
+}
+
 gint64
 restraint_config_get_int64 (gchar *config_file, gchar *section, gchar *key, GError **error)
 {
@@ -37,13 +53,10 @@ restraint_config_get_int64 (gchar *config_file, gchar *section, gchar *key, GErr
     g_return_val_if_fail(error == NULL || *error == NULL, -1);
 
     GKeyFile *keyfile;
-    GKeyFileFlags flags;
     GError *tmp_error = NULL;
 
-    flags = G_KEY_FILE_KEEP_COMMENTS | G_KEY_FILE_KEEP_TRANSLATIONS;
+    keyfile = restraint_config_read_key_file (config_file, NULL);
 
-    keyfile = g_key_file_new ();
-    g_key_file_load_from_file (keyfile, config_file, flags, NULL);
     gint64 value = g_key_file_get_int64 (keyfile,
                                          section,
                                          key,
@@ -69,13 +82,10 @@ restraint_config_get_uint64 (gchar *config_file, gchar *section, gchar *key, GEr
     g_return_val_if_fail(error == NULL || *error == NULL, -1);
 
     GKeyFile *keyfile;
-    GKeyFileFlags flags;
     GError *tmp_error = NULL;
 
-    flags = G_KEY_FILE_KEEP_COMMENTS | G_KEY_FILE_KEEP_TRANSLATIONS;
+    keyfile = restraint_config_read_key_file (config_file, NULL);
 
-    keyfile = g_key_file_new ();
-    g_key_file_load_from_file (keyfile, config_file, flags, NULL);
     guint64 value = g_key_file_get_uint64 (keyfile,
                                            section,
                                            key,
@@ -101,13 +111,10 @@ restraint_config_get_boolean (gchar *config_file, gchar *section, gchar *key, GE
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
     GKeyFile *keyfile;
-    GKeyFileFlags flags;
     GError *tmp_error = NULL;
 
-    flags = G_KEY_FILE_KEEP_COMMENTS | G_KEY_FILE_KEEP_TRANSLATIONS;
+    keyfile = restraint_config_read_key_file (config_file, NULL);
 
-    keyfile = g_key_file_new ();
-    g_key_file_load_from_file (keyfile, config_file, flags, NULL);
     gboolean value = g_key_file_get_boolean (keyfile,
                                             section,
                                             key,
@@ -133,13 +140,10 @@ restraint_config_get_string (gchar *config_file, gchar *section, gchar *key, GEr
     g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
     GKeyFile *keyfile;
-    GKeyFileFlags flags;
     GError *tmp_error = NULL;
 
-    flags = G_KEY_FILE_KEEP_COMMENTS | G_KEY_FILE_KEEP_TRANSLATIONS;
+    keyfile = restraint_config_read_key_file (config_file, NULL);
 
-    keyfile = g_key_file_new ();
-    g_key_file_load_from_file (keyfile, config_file, flags, NULL);
     gchar *value = g_key_file_get_string (keyfile,
                                           section,
                                           key,
@@ -167,10 +171,9 @@ restraint_config_get_keys (gchar *config_file, gchar *section, GError **error)
     GKeyFile *keyfile = NULL;
     GError *tmp_error = NULL;
     gchar **ret = NULL;
-    GKeyFileFlags flags = G_KEY_FILE_KEEP_COMMENTS | G_KEY_FILE_KEEP_TRANSLATIONS;
 
-    keyfile = g_key_file_new ();
-    g_key_file_load_from_file (keyfile, config_file, flags, NULL);
+    keyfile = restraint_config_read_key_file (config_file, NULL);
+
     ret = g_key_file_get_keys(keyfile, section, NULL, &tmp_error);
 
     if (tmp_error) {
@@ -222,15 +225,11 @@ restraint_config_set (gchar *config_file, const gchar *section,
     gchar *s_data = NULL;
     gsize length;
     GKeyFile *keyfile;
-    GKeyFileFlags flags;
     GError *tmp_error = NULL;
-
-    flags = G_KEY_FILE_KEEP_COMMENTS | G_KEY_FILE_KEEP_TRANSLATIONS;
 
     restraint_mkdir_parent (config_file);
 
-    keyfile = g_key_file_new ();
-    g_key_file_load_from_file (keyfile, config_file, flags, NULL);
+    keyfile = restraint_config_read_key_file (config_file, NULL);
 
     if (key && type != -1) {
         va_start (args, type);

--- a/src/config.c
+++ b/src/config.c
@@ -275,11 +275,9 @@ restraint_config_set (gchar *config_file, const gchar *section,
                                  NULL);
     }
 
-    s_data = g_key_file_to_data (keyfile, &length, &tmp_error);
-    if (!s_data) {
-        g_propagate_error (gerror, tmp_error);
-        goto error;
-    }
+    /* g_key_file_to_data never reports errors, and always returns a NULL
+       terminated string. */
+    s_data = g_key_file_to_data (keyfile, &length, NULL);
 
     if (!g_file_set_contents (config_file, s_data, length,  &tmp_error)) {
         g_propagate_error (gerror, tmp_error);

--- a/src/config.c
+++ b/src/config.c
@@ -185,6 +185,16 @@ restraint_config_get_keys (gchar *config_file, gchar *section, GError **error)
     return ret;
 }
 
+static gint
+restraint_mkdir_parent (const gchar *file)
+{
+    g_autofree gchar *dirname = NULL;
+
+    dirname = g_path_get_dirname (file);
+
+    return g_mkdir_with_parents (dirname, 0755 /* drwxr-xr-x */);
+}
+
 void
 restraint_config_trunc (gchar *config_file, GError **error)
 {
@@ -192,9 +202,7 @@ restraint_config_trunc (gchar *config_file, GError **error)
 
     GError *tmp_error = NULL;
 
-    gchar *dirname = g_path_get_dirname (config_file);
-    g_mkdir_with_parents (dirname, 0755 /* drwxr-xr-x */);
-    g_free (dirname);
+    restraint_mkdir_parent (config_file);
 
     if (!g_file_set_contents (config_file, "", -1,  &tmp_error)) {
         g_propagate_error (error, tmp_error);
@@ -219,9 +227,8 @@ restraint_config_set (gchar *config_file, const gchar *section,
 
     flags = G_KEY_FILE_KEEP_COMMENTS | G_KEY_FILE_KEEP_TRANSLATIONS;
 
-    gchar *dirname = g_path_get_dirname (config_file);
-    g_mkdir_with_parents (dirname, 0755 /* drwxr-xr-x */);
-    g_free (dirname);
+    restraint_mkdir_parent (config_file);
+
     keyfile = g_key_file_new ();
     g_key_file_load_from_file (keyfile, config_file, flags, NULL);
 

--- a/src/config.c
+++ b/src/config.c
@@ -29,10 +29,6 @@
 #include "errors.h"
 #include "config.h"
 
-#define unrecognised(error_code, message, ...) g_set_error(error, RESTRAINT_ERROR, \
-        error_code, \
-        message, ##__VA_ARGS__)
-
 gint64
 restraint_config_get_int64 (gchar *config_file, gchar *section, gchar *key, GError **error)
 {


### PR DESCRIPTION
Refactoring in preparation for improving error handling.

- Dedupe `g_key_file_load_from_file ()` and `g_mkdir_with_parents ()` calls
- Remove bogus `disabled_root_access ()` error handling
- Remove unused `unrecognised()` macro

Relates to [bug: 1783283](https://bugzilla.redhat.com/show_bug.cgi?id=1783283).