### PR TITLE
Fix distro version check in 20_unconfined

### DIFF
--- a/plugins/task_run.d/20_unconfined
+++ b/plugins/task_run.d/20_unconfined
@@ -5,25 +5,28 @@
 rstrnt_info "*** Running Plugin: $0"
 
 _is_rhfamily() {
-  local family=$1
-  local op=$2
-  local ver=$3
+  local family="$1"
+  local op="$2"
+  local ver="$3"
   shift 3
-  local the_rpms="$(rpm -q --whatprovides redhat-release)"
-  if [[ -z $the_rpms ]]; then
-    false
+  local the_rpms
+  if rpm -q --whatprovides redhat-release &>/dev/null; then
+    the_rpms="$(rpm -q --whatprovides redhat-release)"
+  elif rpm -q --whatprovides fedora-release &>/dev/null; then
+    the_rpms="$(rpm -q --whatprovides fedora-release)"
   else
-    local the_ver="$(rpm -q --qf="%{VERSION}" $the_rpms | sed "s/^\([0-9]\+\)[^0-9]\+.*$/\1/")"
-    if [[ "$op" == "show" ]]; then
-      rstrnt_debug "Family: $family"
-      rstrnt_debug "Version: $the_ver"
-      rstrnt_debug "Rpms: $the_rpms"
-    elif [[ -n "$op" && -n "$ver" ]]; then
-      eval "[[ $the_ver $op $ver ]]"
-    else
-      true
-    fi
+    return 1
   fi
+  local the_fam="$(rpm -q --qf="%{NAME}" $the_rpms)"
+  the_fam="${the_fam%%-*}"
+  local the_ver="$(rpm -q --qf="%{VERSION}" $the_rpms | sed "s/^\([0-9]\+\)[^0-9]\+.*$/\1/")"
+  if [[ "$op" == "show" ]]; then
+    rstrnt_debug "Family: $the_fam"
+    rstrnt_debug "Version: $the_ver"
+    rstrnt_debug "Rpms: $the_rpms"
+    return 0
+  fi
+  [ "$the_fam" = "$family" ] && [ "$the_ver" "$op" "$ver" ]
 }
 is_rhel() { _is_rhfamily redhat "$1" "$2"; }
 is_fedora() { _is_rhfamily fedora "$1" "$2"; }

--- a/releasenotes/notes/fix-distro-check-in-20_unconfined-224494f732ed2cdd.yaml
+++ b/releasenotes/notes/fix-distro-check-in-20_unconfined-224494f732ed2cdd.yaml
@@ -1,0 +1,8 @@
+fixes:
+  - |
+    Fix distro version check in 20_unconfined
+
+    Make it better at detecting Fedora 34 as Fedora and distinguish RHEL
+    from Fedora in version comparison. The main difference is that it
+    now picks the right SELinux context for test jobs on Fedora 34
+    (Rawhide at the time of writing).


### PR DESCRIPTION
First, on Rawhide fedora-release no longer provides redhat-release (I
mean why should it, really?), so try redhat-release first and then
fedora-release.

Second, the distro family wasn't actually being compared - fix that,
too.

And finally, add quotes where appropriate in this function and refactor
the flow a bit.

Closes: BKR-5033