### PR TITLE
Fix error handling in restraint config functions

### DIFF
--- a/releasenotes/notes/config-error-handling-75c1cc3472c92959.yaml
+++ b/releasenotes/notes/config-error-handling-75c1cc3472c92959.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - |
+    Improve error handling on recipe and task state management
+    Some errors that could indicate a bad saved state are now handled
+    and reported. :bug: '1783283'

--- a/src/task.c
+++ b/src/task.c
@@ -1309,6 +1309,7 @@ connections_write (AppData     *app_data,
     goffset             *offset;
     g_autoptr (SoupURI)  task_output_uri = NULL;
     g_autofree gchar    *section = NULL;
+    g_autoptr (GError)   err = NULL;
 
     if (app_data->tasks == NULL || g_cancellable_is_cancelled (app_data->cancellable))
         return;
@@ -1337,7 +1338,10 @@ connections_write (AppData     *app_data,
                              app_data->cancellable,
                              NULL);
 
-    (void) task_config_set_offset (app_data->config_file, task, path, *offset, NULL);
+    if (!task_config_set_offset (app_data->config_file, task, path, *offset, &err)) {
+        g_warning ("%s(): Failed to set offset in config for task %s: %s",
+                   __func__, task->task_id, err->message);
+    }
 }
 
 void

--- a/tests/test-data/ill_formed.conf
+++ b/tests/test-data/ill_formed.conf
@@ -1,0 +1,1 @@
+Not an INI file.


### PR DESCRIPTION
Previously, the config functions didn't check errors on key file reading. In case of error, the key file structure was left either empty or partially loaded.

Other than the file not found error, which is tolerated on purpose, doesn't make much sense to ignore other errors, and the key file structure shouldn't be used at all after an error.

The case of partially loaded file could be the root cause in bugzilla: 1783283, although the state of the config file at that point is still unknown.
This is not going to fix a bad configuration file, but at least the error will get visibility.

Add error handling for reading key files
Make invalid type errors critical
Print warning in connections write in case of errors in config_set

Note:  This pull request replaces pull #178 which the person who authored left the company
and we lacked privileges to rebase #178 changeset for success of checks.

Bug: 1783283