### PR TITLE
Fix error handling in restraint config functions

### DIFF
--- a/releasenotes/notes/config-error-handling-2fce6360cfa35f3d.yaml
+++ b/releasenotes/notes/config-error-handling-2fce6360cfa35f3d.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - |
+    Improve error handling on recipe and task state management
+    Some errors that could indicate a bad saved state are now handled
+    and reported. :bug: '1783283'

--- a/src/config.c
+++ b/src/config.c
@@ -312,7 +312,8 @@ restraint_config_set (gchar *config_file, const gchar *section,
                                        g_value_get_string (&value));
                 break;
             default:
-                g_warning ("invalid GType\n");
+                g_critical ("%s (): invalid GType", __func__);
+
                 return;
         }
     } else if (key) {

--- a/src/config.c
+++ b/src/config.c
@@ -29,20 +29,42 @@
 #include "errors.h"
 #include "config.h"
 
+#define is_key_file_not_found_error(e) (G_KEY_FILE_ERROR_KEY_NOT_FOUND == e->code \
+                                        || G_KEY_FILE_ERROR_GROUP_NOT_FOUND == e->code)
+
+/*
+ * Returns the content of file into a new GKeyFile structure.
+ *
+ * If the file doesn't exist, an empty GKeyFile is returned.
+ *
+ * If the file cannot be loaded, NULL is returned and err is set.
+ */
 static GKeyFile *
 restraint_config_read_key_file (const gchar  *file,
                                 GError      **err)
 {
     GKeyFile *key_file;
     GKeyFileFlags flags;
+    GError *tmp_err = NULL;
 
     key_file = g_key_file_new ();
 
     flags = G_KEY_FILE_KEEP_COMMENTS | G_KEY_FILE_KEEP_TRANSLATIONS;
 
-    g_key_file_load_from_file (key_file, file, flags, err);
+    if (!g_key_file_load_from_file (key_file, file, flags, &tmp_err)) {
+        if (!g_error_matches (tmp_err, G_FILE_ERROR, G_FILE_ERROR_NOENT))
+            goto error;
+
+        g_clear_error (&tmp_err);
+    }
 
     return key_file;
+
+  error:
+    g_propagate_error (err, tmp_err);
+    g_key_file_free (key_file);
+
+    return NULL;
 }
 
 gint64
@@ -52,26 +74,32 @@ restraint_config_get_int64 (gchar *config_file, gchar *section, gchar *key, GErr
     g_return_val_if_fail(section != NULL, -1);
     g_return_val_if_fail(error == NULL || *error == NULL, -1);
 
-    GKeyFile *keyfile;
+    g_autoptr (GKeyFile) keyfile = NULL;
     GError *tmp_error = NULL;
 
-    keyfile = restraint_config_read_key_file (config_file, NULL);
+    keyfile = restraint_config_read_key_file (config_file, &tmp_error);
+
+    if (NULL != tmp_error)
+        goto error;
 
     gint64 value = g_key_file_get_int64 (keyfile,
                                          section,
                                          key,
                                          &tmp_error);
-    if (tmp_error) {
-        if (tmp_error->code != G_KEY_FILE_ERROR_KEY_NOT_FOUND &&
-            tmp_error->code != G_KEY_FILE_ERROR_GROUP_NOT_FOUND ) {
-            g_propagate_prefixed_error(error, tmp_error, "config get int64,");
-        } else {
-            g_clear_error(&tmp_error);
-        }
+
+    if (NULL != tmp_error) {
+        if (!is_key_file_not_found_error (tmp_error))
+            goto error;
+
+        g_clear_error (&tmp_error);
     }
 
-    g_key_file_free (keyfile);
     return value;
+
+  error:
+    g_propagate_prefixed_error (error, tmp_error, "config get int64,");
+
+    return 0;
 }
 
 guint64
@@ -81,26 +109,31 @@ restraint_config_get_uint64 (gchar *config_file, gchar *section, gchar *key, GEr
     g_return_val_if_fail(section != NULL, -1);
     g_return_val_if_fail(error == NULL || *error == NULL, -1);
 
-    GKeyFile *keyfile;
+    g_autoptr (GKeyFile) keyfile = NULL;
     GError *tmp_error = NULL;
 
-    keyfile = restraint_config_read_key_file (config_file, NULL);
+    keyfile = restraint_config_read_key_file (config_file, &tmp_error);
+
+    if (NULL != tmp_error)
+        goto error;
 
     guint64 value = g_key_file_get_uint64 (keyfile,
                                            section,
                                            key,
                                            &tmp_error);
-    if (tmp_error) {
-        if (tmp_error->code != G_KEY_FILE_ERROR_KEY_NOT_FOUND &&
-            tmp_error->code != G_KEY_FILE_ERROR_GROUP_NOT_FOUND ) {
-            g_propagate_prefixed_error(error, tmp_error, "config get uint64,");
-        } else {
-            g_clear_error(&tmp_error);
-        }
+    if (NULL != tmp_error) {
+        if (!is_key_file_not_found_error (tmp_error))
+            goto error;
+
+        g_clear_error (&tmp_error);
     }
 
-    g_key_file_free (keyfile);
     return value;
+
+  error:
+    g_propagate_prefixed_error (error, tmp_error, "config get uint64,");
+
+    return 0;
 }
 
 gboolean
@@ -110,26 +143,30 @@ restraint_config_get_boolean (gchar *config_file, gchar *section, gchar *key, GE
     g_return_val_if_fail(section != NULL, FALSE);
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-    GKeyFile *keyfile;
+    g_autoptr (GKeyFile) keyfile = NULL;
     GError *tmp_error = NULL;
+    gboolean value;
 
-    keyfile = restraint_config_read_key_file (config_file, NULL);
+    keyfile = restraint_config_read_key_file (config_file, &tmp_error);
 
-    gboolean value = g_key_file_get_boolean (keyfile,
-                                            section,
-                                            key,
-                                            &tmp_error);
-    if (tmp_error) {
-        if (tmp_error->code != G_KEY_FILE_ERROR_KEY_NOT_FOUND &&
-            tmp_error->code != G_KEY_FILE_ERROR_GROUP_NOT_FOUND ) {
-            g_propagate_prefixed_error(error, tmp_error, "config get gboolean,");
-        } else {
-            g_clear_error(&tmp_error);
-        }
+    if (NULL != tmp_error)
+        goto error;
+
+    value = g_key_file_get_boolean (keyfile, section, key, &tmp_error);
+
+    if (NULL != tmp_error) {
+        if (!is_key_file_not_found_error (tmp_error))
+            goto error;
+
+        g_clear_error(&tmp_error);
     }
 
-    g_key_file_free (keyfile);
     return value;
+
+  error:
+    g_propagate_prefixed_error (error, tmp_error, "config get gboolean,");
+
+    return FALSE;
 }
 
 gchar *
@@ -139,26 +176,31 @@ restraint_config_get_string (gchar *config_file, gchar *section, gchar *key, GEr
     g_return_val_if_fail(section != NULL, NULL);
     g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
-    GKeyFile *keyfile;
+    g_autoptr (GKeyFile) keyfile = NULL;
     GError *tmp_error = NULL;
 
-    keyfile = restraint_config_read_key_file (config_file, NULL);
+    keyfile = restraint_config_read_key_file (config_file, &tmp_error);
+
+    if (NULL != tmp_error)
+        goto error;
 
     gchar *value = g_key_file_get_string (keyfile,
                                           section,
                                           key,
                                           &tmp_error);
-    if (tmp_error) {
-        if (tmp_error->code != G_KEY_FILE_ERROR_KEY_NOT_FOUND &&
-            tmp_error->code != G_KEY_FILE_ERROR_GROUP_NOT_FOUND ) {
-            g_propagate_prefixed_error(error, tmp_error, "config get string,");
-        } else {
-            g_clear_error(&tmp_error);
-        }
+    if (NULL != tmp_error) {
+        if (!is_key_file_not_found_error (tmp_error))
+            goto error;
+
+        g_clear_error(&tmp_error);
     }
 
-    g_key_file_free (keyfile);
     return value;
+
+  error:
+    g_propagate_prefixed_error (error, tmp_error, "config get string,");
+
+    return NULL;
 }
 
 gchar **
@@ -168,24 +210,30 @@ restraint_config_get_keys (gchar *config_file, gchar *section, GError **error)
     g_return_val_if_fail(section != NULL, NULL);
     g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
-    GKeyFile *keyfile = NULL;
+    g_autoptr (GKeyFile) keyfile = NULL;
     GError *tmp_error = NULL;
     gchar **ret = NULL;
 
-    keyfile = restraint_config_read_key_file (config_file, NULL);
+    keyfile = restraint_config_read_key_file (config_file, &tmp_error);
+
+    if (NULL != tmp_error)
+        goto error;
 
     ret = g_key_file_get_keys(keyfile, section, NULL, &tmp_error);
 
-    if (tmp_error) {
-        if (tmp_error->code != G_KEY_FILE_ERROR_GROUP_NOT_FOUND ) {
-            g_propagate_prefixed_error(error, tmp_error, "config get keys,");
-        } else {
-            g_clear_error(&tmp_error);
-        }
+    if (NULL != tmp_error) {
+        if (!is_key_file_not_found_error (tmp_error))
+            goto error;
+
+        g_clear_error(&tmp_error);
     }
 
-    g_key_file_free (keyfile);
     return ret;
+
+  error:
+    g_propagate_prefixed_error(error, tmp_error, "config get keys,");
+
+    return NULL;
 }
 
 static gint
@@ -222,14 +270,17 @@ restraint_config_set (gchar *config_file, const gchar *section,
     va_list args;
     GValue value;
 
-    gchar *s_data = NULL;
+    g_autofree gchar *s_data = NULL;
     gsize length;
-    GKeyFile *keyfile;
+    g_autoptr (GKeyFile) keyfile = NULL;
     GError *tmp_error = NULL;
 
     restraint_mkdir_parent (config_file);
 
-    keyfile = restraint_config_read_key_file (config_file, NULL);
+    keyfile = restraint_config_read_key_file (config_file, &tmp_error);
+
+    if (NULL != tmp_error)
+        goto error;
 
     if (key && type != -1) {
         va_start (args, type);
@@ -262,7 +313,7 @@ restraint_config_set (gchar *config_file, const gchar *section,
                 break;
             default:
                 g_warning ("invalid GType\n");
-                goto error;
+                return;
         }
     } else if (key) {
         // no value, remove the key
@@ -281,12 +332,11 @@ restraint_config_set (gchar *config_file, const gchar *section,
        terminated string. */
     s_data = g_key_file_to_data (keyfile, &length, NULL);
 
-    if (!g_file_set_contents (config_file, s_data, length,  &tmp_error)) {
-        g_propagate_error (gerror, tmp_error);
+    if (!g_file_set_contents (config_file, s_data, length,  &tmp_error))
         goto error;
-    }
 
-error:
-    g_free (s_data);
-    g_key_file_free (keyfile);
+    return;
+
+  error:
+    g_propagate_error (gerror, tmp_error);
 }

--- a/src/task.c
+++ b/src/task.c
@@ -1309,6 +1309,7 @@ connections_write (AppData     *app_data,
     goffset             *offset;
     g_autoptr (SoupURI)  task_output_uri = NULL;
     g_autofree gchar    *section = NULL;
+    g_autoptr (GError)   err = NULL;
 
     if (app_data->tasks == NULL || g_cancellable_is_cancelled (app_data->cancellable))
         return;
@@ -1337,7 +1338,10 @@ connections_write (AppData     *app_data,
                              app_data->cancellable,
                              NULL);
 
-    (void) task_config_set_offset (app_data->config_file, task, path, *offset, NULL);
+    if (!task_config_set_offset (app_data->config_file, task, path, *offset, &err)) {
+        g_warning ("%s(): Failed to set offset in config for task %s: %s",
+                   __func__, task->task_id, err->message);
+    }
 }
 
 void

--- a/tests/test-data/ill_formed.conf
+++ b/tests/test-data/ill_formed.conf
@@ -1,0 +1,1 @@
+Not an INI file.


### PR DESCRIPTION
Previously, the config functions didn't check errors on key file reading. In case of error, the key file structure was left either empty or partially loaded.

Other than the file not found error, which is tolerated on purpose, doesn't make much sense to ignore other errors, and the key file structure shouldn't be used at all after an error.

The case of partially loaded file could be the root cause in [bugzilla: 1783283](https://bugzilla.redhat.com/show_bug.cgi?id=1783283), although the state of the config file at that point is still unknown.
This is not going to fix a bad configuration file, but at least the error will get visibility.

- Add error handling for reading key files
- Make invalid type errors critical
- Print warning in connections write in case of errors in config_set

[Bug: 1783283](https://bugzilla.redhat.com/show_bug.cgi?id=1783283)