### PR TITLE
Run tests on Fedora 34

### DIFF
--- a/.github/workflows/review-checks.yml
+++ b/.github/workflows/review-checks.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container: ["fedora:32", "fedora:33", "fedora:rawhide"]
+        container: ["fedora:32", "fedora:33", "fedora:34", "fedora:rawhide"]
     runs-on: ubuntu-latest
     container:
       image: registry.fedoraproject.org/${{ matrix.container }}
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container: ["fedora:32", "fedora:33", "fedora:rawhide"]
+        container: ["fedora:32", "fedora:33", "fedora:34", "fedora:rawhide"]
     runs-on: ubuntu-latest
     container:
       image: registry.fedoraproject.org/${{ matrix.container }}


### PR DESCRIPTION
We are getting close to Fedora 34 release, therefore we should start validating the results on this distribution.

Signed-off-by: Martin Styk <mart.styk@gmail.com>