### PR TITLE
Fix: Upgrade restraint with glib 2.68

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,8 @@
 /third-party/bzip2-1.0.8/
 /third-party/curl-7.68.0.tar.bz2
 /third-party/curl-7.68.0/
-/third-party/glib-2.56.4.tar.xz
-/third-party/glib-2.56.4/
+/third-party/glib-2.68.0.tar.xz
+/third-party/glib-2.68.0/
 /third-party/intltool-0.51.0.tar.gz
 /third-party/intltool-0.51.0/
 /third-party/libarchive-3.4.0.tar.gz

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -56,7 +56,7 @@ versions are listed):
  - zlib-1.2.11
  - bzip2-1.0.8
  - libffi-3.1
- - glib2-2.56.4
+ - glib2-2.68.0
  - libxml2-2.9.10
  - libarchive-3.4.0
  - xz-5.2.4

--- a/restraint.spec
+++ b/restraint.spec
@@ -22,7 +22,7 @@ Source0:	https://github.com/beaker-project/restraint/archive/%{name}-%{version}.
 %if 0%{?with_static:1}
 # Sources for bundled, statically linked libraries
 Source101:      libffi-3.1.tar.gz
-Source102:      glib-2.56.4.tar.xz
+Source102:      glib-2.68.0.tar.xz
 Source103:      zlib-1.2.11.tar.gz
 Source104:      bzip2-1.0.8.tar.gz
 Source105:      libxml2-2.9.10.tar.gz

--- a/third-party/Makefile
+++ b/third-party/Makefile
@@ -2,7 +2,7 @@
 ZLIB = zlib-1.2.11
 BZIP2 = bzip2-1.0.8
 LIBFFI = libffi-3.1
-GLIB = glib-2.56.4
+GLIB = glib-2.68.0
 LIBXML2 = libxml2-2.9.10
 CURL = curl-7.68.0
 LIBARCHIVE = libarchive-3.4.0
@@ -162,7 +162,7 @@ $(LIBFFI).tar.gz:
 
 TAR_BALLS += $(GLIB).tar.xz
 $(GLIB).tar.xz:
-	curl -f -L -O https://ftp.gnome.org/pub/gnome/sources/glib/2.56/$@
+	curl -f -L -O https://ftp.gnome.org/pub/gnome/sources/glib/2.68/$@
 
 TAR_BALLS += $(ZLIB).tar.gz
 $(ZLIB).tar.gz:


### PR DESCRIPTION
Seeing lots of build issues with glib. Time to upgrade.

Issue: 9