### PR TITLE
Temporarily disable deprecation check

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -30,6 +30,8 @@ ifneq ($(DEVEL), 1)
 endif
 
 CFLAGS += -Wall -Werror -std=c99 $(shell pkg-config --cflags $(PACKAGES))
+# Keep this until we have Glib 2.68 in third-party module
+CFLAGS += -Wno-deprecated-declarations
 
 ifeq ($(STATIC), 1)
     # The right thing to do here is `pkg-config --libs --static`, which would

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -21,6 +21,8 @@ SRC_DIR = $(abspath ../src)
 CFLAGS ?= -Og -g
 CFLAGS += -iquote $(SRC_DIR)
 CFLAGS += -Wall -Werror -std=c99 $(shell pkg-config --cflags $(PACKAGES))
+# Keep this until we have Glib 2.68 in third-party module
+CFLAGS += -Wno-deprecated-declarations
 
 ifeq ($(COVERAGE), 1)
     CFLAGS += --coverage


### PR DESCRIPTION
This is not a big deal actually. The only case when we can encounter this is CI (for now).
The reason is that we using distro libraries for dependencies rather than third-party.

Production build is still using an obsolete version of Glib.

Revert this commit when the third-party is using Glib 2.68+ and the code is properly updated. 

Signed-off-by: Martin Styk <mart.styk@gmail.com>