### PR TITLE
Introduce static builds in CI

### DIFF
--- a/.github/workflows/review-checks.yml
+++ b/.github/workflows/review-checks.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container: ["fedora:32", "fedora:33", "fedora:34", "fedora:rawhide", "centos:7", "centos:8"]
+        container: ["fedora:32", "fedora:33", "fedora:34", "fedora:rawhide", "centos:7"]
     container:
       image: ${{ matrix.container }}
 

--- a/.github/workflows/review-checks.yml
+++ b/.github/workflows/review-checks.yml
@@ -3,7 +3,7 @@ name: Review-checks
 on: [pull_request]
 
 jobs:
-  unittests:
+  unit-tests:
     strategy:
       fail-fast: false
       matrix:
@@ -56,4 +56,33 @@ jobs:
       with:
         name: valgrind.out
         path: /home/runner/work/valgrind.out
+
+  static-build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        container: ["fedora:32", "fedora:33", "fedora:34", "fedora:rawhide", "centos:7", "centos:8"]
+    container:
+      image: ${{ matrix.container }}
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Enable EPEL
+        run: |
+          yum install epel-release -y
+        if: contains(matrix.container, 'centos')
+      - name: Install deps
+        run: |
+          yum install -y dnf 'dnf-command(builddep)' tito
+      - name: Enable PowerTools
+        run: |
+          yum config-manager --set-enabled powertools
+        if: contains(matrix.container, 'centos:8')
+      - name: Install restraint deps for static build
+        run: |
+          dnf builddep -y --spec restraint.spec
+      - name: Tito Build
+        run: |
+          tito build --rpm --test
 

--- a/rel-eng/lib/restrainttito.py
+++ b/rel-eng/lib/restrainttito.py
@@ -2,7 +2,6 @@ import os
 import re
 import shutil
 import sys
-from shlex import quote
 
 from tito.builder import Builder
 from tito.common import (
@@ -18,6 +17,11 @@ from tito.common import (
 )
 from tito.exception import TitoException
 from tito.tagger import VersionTagger
+
+try:
+    from shlex import quote
+except ImportError:
+    from pipes import quote
 
 
 class RestraintBuilder(Builder):


### PR DESCRIPTION
Introduce static builds.
This should mimic something close to our BREW builds (except RH, multiarch, etc...).

CentOS 8 is disabled at this moment as buildroot doesn't provide all required packages for compilation.
I would say the whole thing is temporary till we figure out a better solution. I have some ideas already. But for now we need at least something, that we are confided w/ production builds.


Signed-off-by: Martin Styk <mart.styk@gmail.com>