### PR TITLE
Fix: patch m4 to support glibc runtime SIGSTKSZ

### DIFF
--- a/restraint.spec
+++ b/restraint.spec
@@ -167,6 +167,9 @@ rm glib-rhel6-s390.patch
 rm glib-rhel6-s390.patch
 %endif
 %endif
+%if 0%{?fedora} < 35 || 0%{?rhel}
+rm m4-1.4.18-glibc-sigstksz.patch
+%endif
 %if 0%{?fedora} || 0%{?rhel} >= 8
 make PYTHON=%{__python3}
 %else

--- a/third-party/Makefile
+++ b/third-party/Makefile
@@ -259,6 +259,9 @@ $(AUTOCONF)/.patches-done: $(AUTOCONF)
 
 $(M4)/.patches-done: $(M4)
 	patch -d$(M4) -p1 < m4-1.4.18-glibc-change-work-around.patch
+	if [ -e m4-1.4.18-glibc-sigstksz.patch ]; then\
+		patch -d$(M4) -p1 < m4-1.4.18-glibc-sigstksz.patch;\
+	fi
 	touch $@
 
 .PHONY: clean

--- a/third-party/m4-1.4.18-glibc-sigstksz.patch
+++ b/third-party/m4-1.4.18-glibc-sigstksz.patch
@@ -1,0 +1,65 @@
+diff --git a/lib/c-stack.c b/lib/c-stack.c
+index 5353c08..863f764 100644
+--- a/lib/c-stack.c
++++ b/lib/c-stack.c
+@@ -51,13 +51,14 @@
+ typedef struct sigaltstack stack_t;
+ #endif
+ #ifndef SIGSTKSZ
+-# define SIGSTKSZ 16384
+-#elif HAVE_LIBSIGSEGV && SIGSTKSZ < 16384
++#define get_sigstksz()  (16384)
++#elif HAVE_LIBSIGSEGV
+ /* libsigsegv 2.6 through 2.8 have a bug where some architectures use
+    more than the Linux default of an 8k alternate stack when deciding
+    if a fault was caused by stack overflow.  */
+-# undef SIGSTKSZ
+-# define SIGSTKSZ 16384
++#define get_sigstksz() ((SIGSTKSZ) < 16384 ? 16384 : (SIGSTKSZ))
++#else
++#define get_sigstksz() ((SIGSTKSZ))
+ #endif
+ 
+ #include <stdlib.h>
+@@ -131,7 +132,8 @@ die (int signo)
+ /* Storage for the alternate signal stack.  */
+ static union
+ {
+-  char buffer[SIGSTKSZ];
++  /* allocate buffer with size from get_sigstksz() */
++  char *buffer;
+ 
+   /* These other members are for proper alignment.  There's no
+      standard way to guarantee stack alignment, but this seems enough
+@@ -203,10 +205,11 @@ c_stack_action (void (*action) (int))
+   program_error_message = _("program error");
+   stack_overflow_message = _("stack overflow");
+ 
++  alternate_signal_stack.buffer = malloc(get_sigstksz());
+   /* Always install the overflow handler.  */
+   if (stackoverflow_install_handler (overflow_handler,
+                                      alternate_signal_stack.buffer,
+-                                     sizeof alternate_signal_stack.buffer))
++                                     get_sigstksz()))
+     {
+       errno = ENOTSUP;
+       return -1;
+@@ -279,14 +282,15 @@ c_stack_action (void (*action) (int))
+   stack_t st;
+   struct sigaction act;
+   st.ss_flags = 0;
++  alternate_signal_stack.buffer = malloc(get_sigstksz());
+ # if SIGALTSTACK_SS_REVERSED
+   /* Irix mistakenly treats ss_sp as the upper bound, rather than
+      lower bound, of the alternate stack.  */
+-  st.ss_sp = alternate_signal_stack.buffer + SIGSTKSZ - sizeof (void *);
+-  st.ss_size = sizeof alternate_signal_stack.buffer - sizeof (void *);
++  st.ss_sp = alternate_signal_stack.buffer + get_sigstksz() - sizeof (void *);
++  st.ss_size = get_sigstksz() - sizeof (void *);
+ # else
+   st.ss_sp = alternate_signal_stack.buffer;
+-  st.ss_size = sizeof alternate_signal_stack.buffer;
++  st.ss_size = get_sigstksz();
+ # endif
+   r = sigaltstack (&st, NULL);
+   if (r != 0)


### PR DESCRIPTION
glibc made changes to SIGSTKSZ so the value can only be
determined at runtime instead of during preprocessing.
This translate static handling of the variable to dynamic
runtime.

Issue: 201