### PR TITLE
Remove RHEL5&6 from builds

### DIFF
--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -1,3 +1,3 @@
 [dist-git]
 releaser = tito.release.DistGitReleaser
-branches = beaker-harness-rhel-7 beaker-harness-rhel-8 beaker-harness-rhel-6 beaker-harness-rhel-5 eng-fedora-32 eng-fedora-33 eng-fedora-34
+branches = beaker-harness-rhel-7 beaker-harness-rhel-8 eng-fedora-32 eng-fedora-33 eng-fedora-34


### PR DESCRIPTION
Since RHEL 5&6 no longer supported for future releases, removing
it from the list to be built.

Fixes: #213