### PR TITLE
Fix: RHEL-8 build report pcre2-8 not found

### DIFF
--- a/restraint.spec
+++ b/restraint.spec
@@ -109,7 +109,7 @@ BuildRequires:  tar
 %{?with_static:BuildRequires: perl(FindBin), perl(lib)}
 # libselinux Requires.private
 %{?with_static:BuildRequires: libsepol-static}
-%if 0%{?fedora}
+%if 0%{?rhel} >= 8 || 0%{?fedora}
 %{?with_static:BuildRequires: pcre2-static}
 %else
 %{?with_static:BuildRequires: pcre-static}


### PR DESCRIPTION
When Restraint rhel-8 image built, seeing the following error:
/usr/bin/ld: cannot find -lpcre2-8

Issue: 220