### PR TITLE
test: Add fedora:34/Drop 32 to GitHub workflows

### DIFF
--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container: ["fedora:32", "fedora:33"]
+        container: ["fedora:33", "fedora:34"]
     runs-on: ubuntu-latest
     container:
       image: registry.fedoraproject.org/${{ matrix.container }}
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container: ["fedora:32", "fedora:33"]
+        container: ["fedora:33", "fedora:34"]
     runs-on: ubuntu-latest
     container:
       image: registry.fedoraproject.org/${{ matrix.container }}

--- a/.github/workflows/review-checks.yml
+++ b/.github/workflows/review-checks.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container: ["fedora:32", "fedora:33", "fedora:34", "fedora:rawhide"]
+        container: ["fedora:33", "fedora:34", "fedora:rawhide"]
     runs-on: ubuntu-latest
     container:
       image: registry.fedoraproject.org/${{ matrix.container }}
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container: ["fedora:32", "fedora:33", "fedora:34", "fedora:rawhide"]
+        container: ["fedora:33", "fedora:34", "fedora:rawhide"]
     runs-on: ubuntu-latest
     container:
       image: registry.fedoraproject.org/${{ matrix.container }}


### PR DESCRIPTION
For the review-checks.yml file, it was previously updated to
Fedora:34 by pull 192 so only needed to drop fedora:32.