### PR TITLE
Fix: Resolve recent valgrind errors that popped up

### DIFF
--- a/tests/valgrind.supp
+++ b/tests/valgrind.supp
@@ -84,8 +84,16 @@
 {
     pthread_create
     Memcheck:Leak
+    fun:calloc
     ...
     fun:pthread_create@@*
+}
+{
+    pthread_create
+    Memcheck:Leak
+    fun:calloc
+    ...
+    fun:pthread_create*
 }
 
 # libsoup
@@ -634,6 +642,16 @@
    match-leak-kinds: definite
    ...
    fun:__resolv_conf_get_current
+   ...
+   fun:getaddrinfo
+   ...
+}
+{
+   g_thread_proxy
+   Memcheck:Leak
+   match-leak-kinds: definite
+   ...
+   fun:__resolv_context_get
    ...
    fun:getaddrinfo
    ...


### PR DESCRIPTION
Address recent valgrind errors that have suddenly appeared.
These issues are unrelated to restraint code since no code
has been changed since last successful valgrind run.