### PR TITLE
Update systemd OOMPolicy for restraintd so it will continue to run

### DIFF
--- a/init.d/Makefile
+++ b/init.d/Makefile
@@ -7,7 +7,7 @@ install: restraintd
 	install -m0755 -d $(DESTDIR)/etc/init.d
 	install -m0755 restraintd $(DESTDIR)/etc/init.d
 	install -m0755 -d $(DESTDIR)/usr/lib/systemd/system
-	install -m0644 restraintd.service $(DESTDIR)/usr/lib/systemd/system
+	install -m0644 restraintd.service$(SYSTEMD) $(DESTDIR)/usr/lib/systemd/system/restraintd.service
 
 .PHONY: clean
 clean:

--- a/init.d/restraintd.service-legacy
+++ b/init.d/restraintd.service-legacy
@@ -10,7 +10,6 @@ ExecStartPre=/usr/bin/check_beaker
 ExecStart=/usr/bin/restraintd --port 8081
 KillMode=process
 OOMScoreAdjust=-1000
-OOMPolicy=continue
 
 [Install]
 WantedBy=multi-user.target

--- a/restraint.spec
+++ b/restraint.spec
@@ -190,7 +190,11 @@ make -C legacy
 %install
 %{__rm} -rf %{buildroot}
 
+%if 0%{?fedora} || 0%{?rhel} >= 9
 make DESTDIR=%{buildroot} install
+%else
+make DESTDIR=%{buildroot} SYSTEMD=-legacy install
+%endif
 %if %{with_selinux_policy}
 if [ -e "selinux/restraint%{?dist}.pp" ]; then
     install -p -m 644 -D selinux/restraint%{?dist}.pp $RPM_BUILD_ROOT%{_datadir}/selinux/packages/%{name}/restraint.pp


### PR DESCRIPTION
This change keeps restraintd from being oomkilled and since some testing
requires pushing the system into oomkill it's important to not kill the
test runner.

Fixes #224

Change-Id: Iec26c7b00761196a3a2491ba9f8802268283821c