### PR TITLE
Fix: RHEL7 build breakage due to pull rqst 197

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -34,10 +34,13 @@ CFLAGS += -Wall -Werror -std=c99 $(shell pkg-config --cflags $(PACKAGES))
 CFLAGS += -Wno-deprecated-declarations
 
 ifeq ($(STATIC), 1)
-    # The -( -) grouping means we don't have to worry about getting all the
-    # dependent libs in the right order (normally pkg-config would do that for
-    # us).
-    LIBS = -Wl,-\( -Wl,-Bdynamic -lm -pthread -lrt -lresolv -ldl -lutil -Wl,-\) -Wl,-Bstatic -Wl,-\( $(shell pkg-config --static --libs $(PACKAGES)) -Wl,-\) -Wl,-Bdynamic $(LFLAGS)
+    # The LIBS list must start with static then followed with dynamic.
+    # DYNAMICLIBS must be stripped out of THIRDPTYLIBS leaving
+    # the STATICLIBS list.  The DYNAMICLIBS is already listed
+    # in dynamic list so it is redundant.
+    DYNAMICLIBS:=-lm -ldl -lresolve -lrt -lutil
+    THIRDPTYLIBS:=$(shell pkg-config --libs $(PACKAGES))
+    LIBS = -Wl,-Bstatic -Wl,-\( $(filter-out $(DYNAMICLIBS),$(THIRDPTYLIBS)) -llzma -lbz2 -lz -lffi -lssl -lcrypto -Wl,-\) -Wl,-Bdynamic -lm -pthread -lrt -lresolv -ldl -lutil $(LFLAGS)
 else
     LIBS = $(shell pkg-config --libs $(PACKAGES) $(XTRAPKGS)) -lutil -pthread
 endif

--- a/third-party/Makefile
+++ b/third-party/Makefile
@@ -133,7 +133,7 @@ tree/lib/pkgconfig/libsoup-2.4.pc: $(LIBSOUP) $(LIBSOUP)/.patches-done tree/lib/
 	$(MAKE) -C $(LIBSOUP) install
 
 tree/lib/pkgconfig/libcurl.pc: $(CURL) tree/lib/pkgconfig/zlib.pc tree/lib/pkgconfig/openssl.pc
-	( cd $(CURL) && LIBS="-ldl" PKG_CONFIG_PATH=../tree/lib/pkgconfig ./configure --prefix=$(CURDIR)/tree \
+	( cd $(CURL) && PKG_CONFIG_PATH=../tree/lib/pkgconfig ./configure --prefix=$(CURDIR)/tree \
 	    --with-zlib=$(CURDIR)/tree --with-ssl --enable-ipv6 --disable-manual \
 	    --enable-static --disable-shared --disable-ldap --disable-ldaps --without-libidn --without-libssh2 \
 	    --without-brotli --without-libpsl)


### PR DESCRIPTION
RHEL 7 & 8 have failed to build due to changes in pull request 197.
This changeset addresses the handling of third-party libraries
which are causing linkage issue in RHEL7 distro ppc architectures.
Static libraries must proceed dynamic library listings.  This
codeset orders static before dynamic as it was previously and
strips out some known dynamic libraries from 3rd-party static since
they are already defined in the dynamic library listing.