### PR TITLE
Fix: Fail to install - missing GLIBC_PRIVATE

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -38,7 +38,7 @@ ifeq ($(STATIC), 1)
     # DYNAMICLIBS must be stripped out of THIRDPTYLIBS leaving
     # the STATICLIBS list.  The DYNAMICLIBS is already listed
     # in dynamic list so it is redundant.
-    DYNAMICLIBS:=-lm -ldl -lresolve -lrt -lutil
+    DYNAMICLIBS:=-lm -ldl -lresolv -lrt -lutil
     THIRDPTYLIBS:=$(shell pkg-config --libs $(PACKAGES))
     LIBS = -Wl,-Bstatic -Wl,-\( $(filter-out $(DYNAMICLIBS),$(THIRDPTYLIBS)) -llzma -lbz2 -lz -lffi -lssl -lcrypto -Wl,-\) -Wl,-Bdynamic -lm -pthread -lrt -lresolv -ldl -lutil $(LFLAGS)
 else


### PR DESCRIPTION
When I run the latest image (post 0.3.3), I'm seeing the error
'libc.so.6(GLIBC_PRIVATE)(64bit) is needed by restraint.....'. 
The -llresolv must only be in dynamic library.  There was
a typo found in pull 228.  Once I did fixed typo, the rebuilt
image installed for both fedora34 and rhel7.
