### PR TITLE
Fix: f35/rawhide failing to build

### DIFF
--- a/restraint.spec
+++ b/restraint.spec
@@ -171,6 +171,7 @@ export CFLAGS="$RPM_OPT_FLAGS -march=i486"
 pushd third-party
 %if 0%{?fedora} < 35 || 0%{?rhel}
 rm m4-1.4.18-glibc-sigstksz.patch
+rm glib_new_close_range_arg.patch
 %endif
 %if 0%{?fedora} || 0%{?rhel} >= 8
 make PYTHON=%{__python3}

--- a/third-party/Makefile
+++ b/third-party/Makefile
@@ -231,6 +231,9 @@ $(LIBFFI)/.patches-done: $(LIBFFI)
 	touch $@
 
 $(GLIB)/.patches-done: $(GLIB)
+	if [ -e glib_new_close_range_arg.patch ]; then\
+		patch -d$(GLIB) -p1 < glib_new_close_range_arg.patch;\
+	fi
 	touch $@
 
 $(INTLTOOL)/.patches-done: $(INTLTOOL)

--- a/third-party/glib_new_close_range_arg.patch
+++ b/third-party/glib_new_close_range_arg.patch
@@ -1,0 +1,13 @@
+diff --git a/glib/gspawn.c b/glib/gspawn.c
+index 899647c2f..3073a10a4 100644
+--- a/glib/gspawn.c
++++ b/glib/gspawn.c
+@@ -1520,7 +1520,7 @@ safe_closefrom (int lowfd)
+    *
+    * Handle ENOSYS in case it’s supported in libc but not the kernel; if so,
+    * fall back to safe_fdwalk(). */
+-  if (close_range (lowfd, G_MAXUINT) != 0 && errno == ENOSYS)
++  if (close_range (lowfd, G_MAXUINT, 0) != 0 && errno == ENOSYS)
+ #endif  /* HAVE_CLOSE_RANGE */
+   (void) safe_fdwalk (close_func, GINT_TO_POINTER (lowfd));
+ #endif


### PR DESCRIPTION
Changes in rawhide causing restraint images to fail to build.  The
cause was recent distros added an extra argument to the function
close_range().  This changeset applies a patch for fedora35 only.