### PR TITLE
Fix: RHEL9 beta build failing

### DIFF
--- a/restraint.spec
+++ b/restraint.spec
@@ -169,7 +169,7 @@ export CFLAGS="$RPM_OPT_FLAGS -march=i486"
 
 %if 0%{?with_static:1}
 pushd third-party
-%if 0%{?fedora} < 35 || 0%{?rhel}
+%if ( 0%{?fedora} && 0%{?fedora} < 35 ) || ( 0%{?rhel} && 0%{?rhel} < 9 )
 rm m4-1.4.18-glibc-sigstksz.patch
 rm glib_new_close_range_arg.patch
 %endif


### PR DESCRIPTION
RHEL9 failing to build similar to Fedora35 build failures.  Need to
apply same third-party patches as done with Fedora35.