### PR TITLE
ci: temporarily disable seccomp for Docker containers

### DIFF
--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: registry.fedoraproject.org/${{ matrix.container }}
+      options: --security-opt seccomp=unconfined
 
     steps:
     - uses: actions/checkout@v1
@@ -41,6 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: registry.fedoraproject.org/${{ matrix.container }}
+      options: --security-opt seccomp=unconfined
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/review-checks.yml
+++ b/.github/workflows/review-checks.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: registry.fedoraproject.org/${{ matrix.container }}
+      options: --security-opt seccomp=unconfined
 
     steps:
     - uses: actions/checkout@v1
@@ -38,6 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: registry.fedoraproject.org/${{ matrix.container }}
+      options: --security-opt seccomp=unconfined
 
     steps:
     - uses: actions/checkout@v1
@@ -65,6 +67,7 @@ jobs:
         container: ["fedora:32", "fedora:33", "fedora:34", "fedora:rawhide", "centos:7"]
     container:
       image: ${{ matrix.container }}
+      options: --security-opt seccomp=unconfined
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Current Docker version on Ubuntu 20.04 used by GH Actions suffers from
an incompatibility with newer glibc [0] used by Fedora Rawhide, causing
Rawhide containers in CI to fail with:

```
Errors during downloading metadata for repository 'fedora-cisco-openh264':
  - Curl error (6): Couldn't resolve host name for https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-rawhide&arch=x86_64 [getaddrinfo() thread failed to start]
```

glibc 2.34 and later tries to use the clone3 syscall (for
hardware-assisted security hardening on x86_64), and falls back to clone2
on ENOSYS. However, with the current seccomp profile Docker returns EPERM
instead, which is considered a "hard" fail.

A fix [1] has been merged in upstream, but until then let's run the CI Docker
containers without any seccomp profiles to allow Rawhide jobs to to their job.
(I tried to disable seccomp only for the Rawhide jobs, but I couldn't procure
any solution which wouldn't make my eyes bleed...)

[0] https://github.com/moby/moby/issues/42680
[1] https://github.com/moby/moby/pull/42681