### PR TITLE
Enable Fedora 35 prerelease

### DIFF
--- a/.github/workflows/review-checks.yml
+++ b/.github/workflows/review-checks.yml
@@ -7,10 +7,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container: ["fedora:33", "fedora:34", "fedora:rawhide"]
+        version: ["33", "34", "35", "rawhide"]
     runs-on: ubuntu-latest
     container:
-      image: registry.fedoraproject.org/${{ matrix.container }}
+      image: registry.fedoraproject.org/fedora:${{ matrix.version }}
 
     steps:
     - uses: actions/checkout@v1
@@ -34,10 +34,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container: ["fedora:33", "fedora:34", "fedora:rawhide"]
+        version: ["33", "34", "35", "rawhide"]
     runs-on: ubuntu-latest
     container:
-      image: registry.fedoraproject.org/${{ matrix.container }}
+      image: registry.fedoraproject.org/fedora:${{ matrix.version }}
 
     steps:
     - uses: actions/checkout@v1
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container: ["fedora:32", "fedora:33", "fedora:34", "fedora:rawhide", "centos:7"]
+        container: ["fedora:32", "fedora:33", "fedora:34", "fedora:35", "fedora:rawhide", "centos:7"]
     container:
       image: ${{ matrix.container }}
 

--- a/.github/workflows/review-checks.yml
+++ b/.github/workflows/review-checks.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: registry.fedoraproject.org/fedora:${{ matrix.version }}
+      options: --security-opt seccomp=unconfined
 
     steps:
     - uses: actions/checkout@v1
@@ -38,6 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: registry.fedoraproject.org/fedora:${{ matrix.version }}
+      options: --security-opt seccomp=unconfined
 
     steps:
     - uses: actions/checkout@v1
@@ -65,6 +67,7 @@ jobs:
         container: ["fedora:32", "fedora:33", "fedora:34", "fedora:35", "fedora:rawhide", "centos:7"]
     container:
       image: ${{ matrix.container }}
+      options: --security-opt seccomp=unconfined
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Signed-off-by: Martin Styk <mart.styk@gmail.com>

I had to disable seccomp due to incompatibility between test runner and Fedora Glib version.