### PR TITLE
Add ability to abort recipe on fetch failures

### DIFF
--- a/docs/jobs.rst
+++ b/docs/jobs.rst
@@ -109,6 +109,10 @@ The first example shows fetching a task from git.
 
  <fetch ssl_verify="off" url="https://fedorapeople.org/cgit/bpeck/public_git/tests.git/snapshot/tests-master.tar.gz#kernel/performance/fs_mark" />
 
+ OR
+
+ <fetch recipe_abort_on_fail="true" url="https://fedorapeople.org/cgit/bpeck/public_git/tests.git/snapshot/tests-master.tar.gz#kernel/performance/fs_mark" />
+
 The fetch node accepts git URI's that conform to the following:
 
 * Prefixed with git:// OR use tarballs with http:// and cgit can serve them
@@ -123,6 +127,8 @@ The fetch node accepts git URI's that conform to the following:
   there is not a preceding slash here.
 * If you need to disable SSL certificate checking you can set ssl_verify
   parameter to "off".
+* If you need to abort the whole recipe on a fetch failure you can set
+  recipe_abort_on_fail parameter to "true".
 
 Restraint uses git's archive protocol to retrieve the contents so make sure
 your git server has enabled this. You can enable this on most servers by

--- a/src/recipe.c
+++ b/src/recipe.c
@@ -257,6 +257,14 @@ static Task *parse_task(xmlNode *task_node, Recipe *recipe, GError **error) {
         }
         xmlFree(ssl_verify);
 
+        xmlChar *fetch_abort_recipe = xmlGetNoNsProp(fetch, (xmlChar *)"recipe_abort_on_fail");
+        if (fetch_abort_recipe == NULL || g_strcmp0((char*)fetch_abort_recipe, "true") != 0) {
+            task->fetch_abort_recipe = FALSE;
+        } else {
+            task->fetch_abort_recipe = TRUE;
+        }
+        xmlFree(fetch_abort_recipe);
+
         task->path = g_build_filename(task->recipe->base_path,
                 task->fetch.url->host,
                 task->fetch.url->path,

--- a/src/task.c
+++ b/src/task.c
@@ -115,6 +115,10 @@ fetch_finish_callback (GError *error, guint32 match_cnt,
             return;
         } else {
             g_propagate_error (&task->error, error);
+            if (task->fetch_abort_recipe) {
+                g_cancellable_cancel(app_data->cancellable);
+                app_data->aborted = ABORTED_RECIPE;
+            }
             task->state = TASK_COMPLETE;
         }
     } else {

--- a/src/task.h
+++ b/src/task.h
@@ -87,6 +87,8 @@ typedef struct RstrntTask {
     /* Whether to keep task changes */
     gboolean keepchanges;
     gboolean ssl_verify;
+    /* Whether a fetch failure aborts whole recipe */
+    gboolean fetch_abort_recipe;
     /* List of Params */
     GList *params;
     /* List of Roles */


### PR DESCRIPTION
Using <fetch> parameter "recipe_abort_on_fail=true" to abort the whole recipe when the git fetch command fails instead of just the task.